### PR TITLE
Fixes NPE Crash on disable

### DIFF
--- a/src/com/Jessy1237/DwarfCraft/DwarfCraft.java
+++ b/src/com/Jessy1237/DwarfCraft/DwarfCraft.java
@@ -351,7 +351,9 @@ public class DwarfCraft extends JavaPlugin
             }
         }
 
-        CitizensAPI.getTraitFactory().deregisterTrait( trainerTrait );
+        if (trainerTrait != null) {
+            CitizensAPI.getTraitFactory().deregisterTrait(trainerTrait);
+        }
     }
 
     /**
@@ -370,7 +372,7 @@ public class DwarfCraft extends JavaPlugin
         if ( pm.getPlugin( "Vault" ) == null || pm.getPlugin( "Vault" ).isEnabled() == false )
         {
             System.out.println( "[DwarfCraft] Couldn't find Vault!" );
-            System.out.println( "[DwarfCraft] DwarfCraft now disabiling..." );
+            System.out.println( "[DwarfCraft] DwarfCraft now disabling..." );
             pm.disablePlugin( this );
             return;
         }
@@ -409,7 +411,7 @@ public class DwarfCraft extends JavaPlugin
         if ( pm.getPlugin( "Citizens" ) == null || pm.getPlugin( "Citizens" ).isEnabled() == false )
         {
             System.out.println( "[DwarfCraft] Couldn't find Citizens!" );
-            System.out.println( "[DwarfCraft] DwarfCraft now disabiling..." );
+            System.out.println( "[DwarfCraft] DwarfCraft now disabling..." );
             pm.disablePlugin( this );
             return;
         }


### PR DESCRIPTION
This commit fixes a NullPointerException crash with DwarfCraft. This luckily only happens on plugin disable. This is caused by the onEnable method calling onDisable early before the trait information is available such as in the case when a required plugin such as Vault, PermsEx, or Citizens is not found. Since the trait information is not set yet the deregisterTrait() call in onDisable will crash with a NPE. Since the trait isn't registered until later in onEnable it is safe to skip the deregisterTrait call if the trait information is null. This prevents the plugin from crashing when disabling due to a required plugin not being found.
