### PR TITLE
Excludes Log Block Questioner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,12 @@
             <artifactId>logblock</artifactId>
             <version>1.10.1-SNAPSHOT</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>de.diddiz</groupId>
+                    <artifactId>questioner</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This updates the pom.xml file to exclude the Log Block Questioner dependency. This dependency is not required by DwarfCraft and is not available at the repo and will only fail to download. This commit adds an exclusion to exclude it from the download.
