### PR TITLE
Fixes the Skill Info for a trainer

### DIFF
--- a/src/com/Jessy1237/DwarfCraft/Out.java
+++ b/src/com/Jessy1237/DwarfCraft/Out.java
@@ -117,7 +117,7 @@ public class Out
     public boolean printSkillInfo( CommandSender sender, Skill skill, DCPlayer dCPlayer, int maxTrainLevel )
     {
         // general line
-        sendMessage( sender, Messages.skillInfoHeader.replaceAll( "%playername%", dCPlayer.getPlayer().getDisplayName() ).replaceAll( "%skillid%", "" + skill.getId() ).replaceAll( "%skilllevel5", "" + skill.getLevel() )
+        sendMessage( sender, Messages.skillInfoHeader.replaceAll( "%playername%", dCPlayer.getPlayer().getDisplayName() ).replaceAll( "%skillid%", "" + skill.getId() ).replaceAll( "%skilllevel%", "" + skill.getLevel() )
                 .replaceAll( "%maxskilllevel%", "" + plugin.getConfigManager().getMaxSkillLevel() ) );
 
         // effects lines


### PR DESCRIPTION
Fixes a bug where the skill info for a trainer wasn't correctly replacing the players level

![2016-08-19_05 58 00](https://cloud.githubusercontent.com/assets/1168966/17806615/8ae496ce-65d3-11e6-9468-25eab5329aec.png)
