### PR TITLE
Debug Message cleanup

### DIFF
--- a/src/com/Jessy1237/DwarfCraft/ConfigManager.java
+++ b/src/com/Jessy1237/DwarfCraft/ConfigManager.java
@@ -604,7 +604,6 @@ public final class ConfigManager
 
                 if ( message != null || !message.trim().equals( "" ) || !message.equals( null ) )
                 {
-                    System.out.println( name + ", " + message );
                     if ( name.equalsIgnoreCase( "Server Rules" ) )
                         Messages.serverRules = message;
                     if ( name.equalsIgnoreCase( "Server Rules prefix" ) )


### PR DESCRIPTION
Removes the excessive debug output off all the messages.config messages to the console.
