### PR TITLE
Adds LogBlock soft dependency

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -4,6 +4,7 @@ author: Jessy1237
 main: com.Jessy1237.DwarfCraft.DwarfCraft
 version: 3.0.1
 depend: [Vault, Citizens]
+softdepend: [LogBlock]
 commands: 
    dcreload: 
       description: Reloads the DwarfCraft plugin.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>DwarfCraft</artifactId>
     <name>DwarfCraft</name>
     <packaging>jar</packaging>
-    <version>3.0</version>
+    <version>3.0.1</version>
 
     <repositories>
         <repository>


### PR DESCRIPTION
Added a soft dependency for LogBlock in the plugin.yml. This ensures that Spigot will load LogBlock before DwarfCraft in the case where LogBlock is on the server. This is not a required dependency and DwarfCraft will continue to work and load in the case that LogBlock is not on the server. If LogBlock is not loaded before DwarfCraft, DwarfCraft will not be able find the plugin in its onEnable. Without this there is no guarantee by Spigot that LogBlock will load before DwarfCraft.
