### PR TITLE
Fixed Item Name Output

### DIFF
--- a/src/com/Jessy1237/DwarfCraft/DwarfTrainer.java
+++ b/src/com/Jessy1237/DwarfCraft/DwarfTrainer.java
@@ -190,7 +190,7 @@ public final class DwarfTrainer
             }
             if ( costStack.getAmount() == 0 )
             {
-                plugin.getOut().sendMessage( player, Messages.noMoreItemNeeded.replaceAll( "%itemname", plugin.getUtil().getCleanName( costStack ) ), tag );
+                plugin.getOut().sendMessage( player, Messages.noMoreItemNeeded.replaceAll( "%itemname%", plugin.getUtil().getCleanName( costStack ) ), tag );
                 continue;
             }
             if ( !player.getInventory().contains( costStack.getTypeId() ) )
@@ -276,7 +276,7 @@ public final class DwarfTrainer
             }
             if ( costStack.getAmount() == 0 )
             {
-                plugin.getOut().sendMessage( player, Messages.noMoreItemNeeded.replaceAll( "%itemname", plugin.getUtil().getCleanName( costStack ) ), tag );
+                plugin.getOut().sendMessage( player, Messages.noMoreItemNeeded.replaceAll( "%itemname%", plugin.getUtil().getCleanName( costStack ) ), tag );
             }
             else
             {


### PR DESCRIPTION
Fixes a bug when training with a trainer where the item name wouldnt be replaced correctly

![2016-08-19_07 17 45](https://cloud.githubusercontent.com/assets/1168966/17808457/50f7c4e4-65de-11e6-8cc2-4ac3eafc9388.png)
