### PR TITLE
Compile against Spigot 1.11 and update dependencies

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: DwarfCraft
 description: A skills and progression plugin for character development in RPG worlds.
 author: Jessy1237
 main: com.Jessy1237.DwarfCraft.DwarfCraft
-version: 3.1.5
+version: 3.1.6
 depend: [Vault, Citizens]
 softdepend: [LogBlock]
 commands: 

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <artifactId>DwarfCraft</artifactId>
     <name>DwarfCraft</name>
     <packaging>jar</packaging>
-    <version>3.1.5</version>
+    <version>3.1.6</version>
 
     <repositories>
         <repository>
             <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots</url>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
             <id>citizens-npcs</id>
@@ -31,21 +31,21 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.10.2-R0.1-SNAPSHOT</version>
+            <version>1.11-R0.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <!--Bukkit API-->
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.10.2-R0.1-SNAPSHOT</version>
+            <version>1.11-R0.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <!--Citizens API-->
         <dependency>
             <groupId>net.citizensnpcs</groupId>
             <artifactId>citizensapi</artifactId>
-            <version>2.0.20-SNAPSHOT</version>
+            <version>2.0.21-SNAPSHOT</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
Also bumps plugin version
Latest Citizens dev build is required (citizens-2.0.21-SNAPSHOT.jar) for Citizens and DwarfCraft to load.
Will need more testing of the various skills but no obvious bugs so far.