### PR TITLE
Major refactors and begin implementation on List Trainers GUI

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -85,7 +85,7 @@ commands:
       description: Displays a list of trainers and greeters on the server.
       usage: |
              /listtrainers [PageNumber]
-      aliases: [listtrainer, lt]
+      aliases: [lt]
    races:
       description:
       usage:

--- a/src/com/Jessy1237/DwarfCraft/CommandParser.java
+++ b/src/com/Jessy1237/DwarfCraft/CommandParser.java
@@ -17,7 +17,7 @@ public final class CommandParser
     private final DwarfCraft plugin;
     private CommandSender sender;
     private String[] input;
-    private DCPlayer target = null;
+    private DwarfPlayer target = null;
 
     public CommandParser( final DwarfCraft plugin, CommandSender sender, String[] args )
     {
@@ -34,13 +34,13 @@ public final class CommandParser
         {
             for ( Object o : desiredArguments )
             {
-                if ( o instanceof DCPlayer )
+                if ( o instanceof DwarfPlayer)
                     output.add( parseDwarf( arrayIterator ) );
                 else if ( o instanceof Player )
                     output.add( parsePlayer( arrayIterator ) );
-                else if ( o instanceof Skill )
+                else if ( o instanceof DwarfSkill)
                     output.add( parseSkill( arrayIterator ) );
-                else if ( o instanceof Effect )
+                else if ( o instanceof DwarfEffect)
                     output.add( parseEffect( arrayIterator ) );
                 else if ( o instanceof Boolean )
                     output.add( parseConfirm( arrayIterator ) );
@@ -89,10 +89,10 @@ public final class CommandParser
     }
 
     @SuppressWarnings( "deprecation" )
-    private DCPlayer parseDwarf( int argNumber ) throws DCCommandException
+    private DwarfPlayer parseDwarf(int argNumber ) throws DCCommandException
     {
         Player player;
-        DCPlayer dCPlayer = null;
+        DwarfPlayer dCPlayer = null;
         try
         {
             String dwarf = input[argNumber];
@@ -128,10 +128,10 @@ public final class CommandParser
 
     }
 
-    private Effect parseEffect( int argNumber ) throws DCCommandException
+    private DwarfEffect parseEffect(int argNumber ) throws DCCommandException
     {
         String inputString = input[argNumber];
-        Effect effect;
+        DwarfEffect effect;
         int effectId;
 
         try
@@ -194,9 +194,9 @@ public final class CommandParser
         return null;
     }
 
-    private Skill parseSkill( int argNumber ) throws DCCommandException
+    private DwarfSkill parseSkill(int argNumber ) throws DCCommandException
     {
-        Skill skill = null;
+        DwarfSkill skill = null;
         String inputString = input[argNumber];
         if ( inputString.equalsIgnoreCase( "all" ) )
             return null;
@@ -217,7 +217,7 @@ public final class CommandParser
                     throw new DCCommandException( plugin, Type.PARSESKILLFAIL );
                 for ( int i : plugin.getConfigManager().getAllSkills( target.getRace() ) )
                 {
-                    Skill s = plugin.getConfigManager().getGenericSkill( i );
+                    DwarfSkill s = plugin.getConfigManager().getGenericSkill( i );
                     if ( s.getDisplayName().regionMatches( 0, inputString, 0, 8 ) )
                         return s;
                 }

--- a/src/com/Jessy1237/DwarfCraft/ConfigManager.java
+++ b/src/com/Jessy1237/DwarfCraft/ConfigManager.java
@@ -52,12 +52,12 @@ public final class ConfigManager
     private String vanillaRace;
     private String prefixStr;
 
-    private HashMap<Integer, Skill> skillsArray = new HashMap<Integer, Skill>();
+    private HashMap<Integer, DwarfSkill> skillsArray = new HashMap<Integer, DwarfSkill>();
     public ArrayList<World> worlds = new ArrayList<World>();
     private HashMap<String, ArrayList<Integer>> blockGroups = new HashMap<String, ArrayList<Integer>>();
     private HashMap<String, ArrayList<Integer>> toolGroups = new HashMap<String, ArrayList<Integer>>();
 
-    private ArrayList<Race> raceList = new ArrayList<Race>();
+    private ArrayList<DwarfRace> raceList = new ArrayList<DwarfRace>();
     private String defaultRace;
 
     public boolean sendGreeting = false;
@@ -90,11 +90,11 @@ public final class ConfigManager
             {
                 // Runs the proceeding events after all the config files are
                 // read so that the skillArray is complete with effects
-                DwarfCraftLoadSkillsEvent e = new DwarfCraftLoadSkillsEvent( ( HashMap<Integer, Skill> ) skillsArray.clone() );
+                DwarfCraftLoadSkillsEvent e = new DwarfCraftLoadSkillsEvent( ( HashMap<Integer, DwarfSkill> ) skillsArray.clone() );
                 plugin.getServer().getPluginManager().callEvent( e );
                 skillsArray = e.getSkills();
 
-                DwarfCraftLoadRacesEvent event = new DwarfCraftLoadRacesEvent( ( ArrayList<Race> ) raceList.clone() );
+                DwarfCraftLoadRacesEvent event = new DwarfCraftLoadRacesEvent( ( ArrayList<DwarfRace> ) raceList.clone() );
                 plugin.getServer().getPluginManager().callEvent( event );
                 raceList = event.getRaces();
 
@@ -109,10 +109,10 @@ public final class ConfigManager
 
     }
 
-    public HashMap<Integer, Skill> getAllSkills()
+    public HashMap<Integer, DwarfSkill> getAllSkills()
     {
-        HashMap<Integer, Skill> newSkillsArray = new HashMap<Integer, Skill>();
-        for ( Skill s : skillsArray.values() )
+        HashMap<Integer, DwarfSkill> newSkillsArray = new HashMap<Integer, DwarfSkill>();
+        for ( DwarfSkill s : skillsArray.values() )
         {
             if ( newSkillsArray.containsKey( s.getId() ) )
                 continue;
@@ -121,9 +121,9 @@ public final class ConfigManager
         return newSkillsArray;
     }
 
-    public Race getRace( String Race )
+    public DwarfRace getRace(String Race )
     {
-        for ( Race r : raceList )
+        for ( DwarfRace r : raceList )
         {
             if ( r != null )
             {
@@ -138,16 +138,16 @@ public final class ConfigManager
 
     public ArrayList<Integer> getAllSkills( String Race )
     {
-        Race r = getRace( Race );
+        DwarfRace r = getRace( Race );
         if ( r != null )
             return r.getSkills();
         return null;
     }
 
-    protected Skill getGenericSkill( int skillId )
+    protected DwarfSkill getGenericSkill(int skillId )
     {
 
-        for ( Skill s : skillsArray.values() )
+        for ( DwarfSkill s : skillsArray.values() )
         {
             if ( s.getId() == skillId )
                 return s.clone();
@@ -341,7 +341,7 @@ public final class ConfigManager
             {
                 if ( getRace( vanillaRace ) == null )
                 {
-                    raceList.add( new Race( vanillaRace, new ArrayList<Integer>(), "The all round balanced race (vanilla)." ) );
+                    raceList.add( new DwarfRace( vanillaRace, new ArrayList<Integer>(), "The all round balanced race (vanilla)." ) );
                     System.out.println( "[DwarfCraft] Loaded vanilla race: " + vanillaRace );
                 }
             }
@@ -416,8 +416,8 @@ public final class ConfigManager
             while ( records.hasNext() )
             {
                 CSVRecord item = records.next();
-                Effect effect = new Effect( item, plugin );
-                Skill skill = skillsArray.get( effect.getId() / 10 );
+                DwarfEffect effect = new DwarfEffect( item, plugin );
+                DwarfSkill skill = skillsArray.get( effect.getId() / 10 );
                 if ( skill != null )
                 {
                     skill.getEffects().add( effect );
@@ -450,7 +450,7 @@ public final class ConfigManager
             boolean desc = false;
             boolean skills = false;
             boolean prefix = false;
-            Race race = null;
+            DwarfRace race = null;
             while ( line != null )
             {
                 if ( line.length() == 0 )
@@ -471,7 +471,7 @@ public final class ConfigManager
                 }
                 if ( theline[0].equalsIgnoreCase( "Name" ) )
                 {
-                    race = new Race( theline[1].trim() );
+                    race = new DwarfRace( theline[1].trim() );
                     name = true;
                     line = br.readLine();
                 }
@@ -798,7 +798,7 @@ public final class ConfigManager
                 CSVRecord item = records.next();
 
                 @SuppressWarnings( "deprecation" )
-                Skill skill = new Skill( item.getInt( "ID" ), item.getString( "Name" ), 0, new ArrayList<Effect>(), new TrainingItem( plugin.getUtil().parseItem( item.getString( "Item1" ) ), item.getDouble( "Item1Base" ), item.getInt( "Item1Max" ) ), new TrainingItem( plugin.getUtil()
+                DwarfSkill skill = new DwarfSkill( item.getInt( "ID" ), item.getString( "Name" ), 0, new ArrayList<DwarfEffect>(), new TrainingItem( plugin.getUtil().parseItem( item.getString( "Item1" ) ), item.getDouble( "Item1Base" ), item.getInt( "Item1Max" ) ), new TrainingItem( plugin.getUtil()
                         .parseItem( item.getString( "Item2" ) ), item.getDouble( "Item2Base" ), item.getInt( "Item2Max" ) ), new TrainingItem( plugin.getUtil().parseItem( item.getString( "Item3" ) ), item.getDouble( "Item3Base" ), item.getInt( "Item3Max" ) ), Material
                                 .getMaterial( item.getInt( "Held" ) ) );
 
@@ -963,14 +963,14 @@ public final class ConfigManager
         return defaultRace;
     }
 
-    public ArrayList<Race> getRaceList()
+    public ArrayList<DwarfRace> getRaceList()
     {
         return raceList;
     }
 
     public boolean checkRace( String name )
     {
-        for ( Race r : raceList )
+        for ( DwarfRace r : raceList )
         {
             if ( r != null )
             {

--- a/src/com/Jessy1237/DwarfCraft/DataManager.java
+++ b/src/com/Jessy1237/DwarfCraft/DataManager.java
@@ -30,7 +30,7 @@ import net.citizensnpcs.api.npc.NPC;
 public class DataManager
 {
 
-    private List<DCPlayer> dwarves = new ArrayList<DCPlayer>();
+    private List<DwarfPlayer> dwarves = new ArrayList<DwarfPlayer>();
     public HashMap<Integer, DwarfVehicle> vehicleMap = new HashMap<Integer, DwarfVehicle>();
     public HashMap<Integer, DwarfTrainer> trainerList = new HashMap<Integer, DwarfTrainer>();
     private HashMap<String, GreeterMessage> greeterMessageList = new HashMap<String, GreeterMessage>();
@@ -98,13 +98,13 @@ public class DataManager
         return false;
     }
 
-    public DCPlayer createDwarf( Player player )
+    public DwarfPlayer createDwarf(Player player )
     {
-        DCPlayer newDwarf = new DCPlayer( plugin, player );
+        DwarfPlayer newDwarf = new DwarfPlayer( plugin, player );
         newDwarf.setRace( plugin.getConfigManager().getDefaultRace() );
         newDwarf.setSkills( plugin.getConfigManager().getAllSkills() );
 
-        for ( Skill skill : newDwarf.getSkills().values() )
+        for ( DwarfSkill skill : newDwarf.getSkills().values() )
         {
             skill.setLevel( 0 );
             skill.setDeposit1( 0 );
@@ -296,14 +296,14 @@ public class DataManager
     }
 
     /**
-     * Finds a DCPlayer from the server's static list based on player's name
+     * Finds a DwarfPlayer from the server's static list based on player's name
      * 
      * @param player
-     * @return DCPlayer or null
+     * @return DwarfPlayer or null
      */
-    public DCPlayer find( Player player )
+    public DwarfPlayer find(Player player )
     {
-        for ( DCPlayer d : dwarves )
+        for ( DwarfPlayer d : dwarves )
         {
             if ( d != null )
             {
@@ -320,19 +320,19 @@ public class DataManager
         return null;
     }
 
-    protected DCPlayer findOffline( UUID uuid )
+    protected DwarfPlayer findOffline(UUID uuid )
     {
-        DCPlayer dCPlayer = createDwarf( null );
+        DwarfPlayer dCPlayer = createDwarf( null );
         if ( checkDwarfData( dCPlayer, uuid ) )
             return dCPlayer;
         else
         {
-            // No DCPlayer or data found
+            // No DwarfPlayer or data found
             return null;
         }
     }
 
-    public void createDwarfData( DCPlayer dCPlayer )
+    public void createDwarfData( DwarfPlayer dCPlayer )
     {
         try
         {
@@ -348,7 +348,7 @@ public class DataManager
         }
     }
 
-    public boolean checkDwarfData( DCPlayer player )
+    public boolean checkDwarfData( DwarfPlayer player )
     {
         return checkDwarfData( player, player.getPlayer().getUniqueId() );
     }
@@ -359,7 +359,7 @@ public class DataManager
      * @param player
      * @param name
      */
-    private boolean checkDwarfData( DCPlayer player, UUID uuid )
+    private boolean checkDwarfData(DwarfPlayer player, UUID uuid )
     {
         try
         {
@@ -385,7 +385,7 @@ public class DataManager
             {
                 int skillID = rs.getInt( "id" );
                 int level = rs.getInt( "level" );
-                Skill skill = player.getSkill( skillID );
+                DwarfSkill skill = player.getSkill( skillID );
                 if ( skill != null )
                 {
                     skill.setLevel( level );
@@ -519,26 +519,26 @@ public class DataManager
         return -1;
     }
 
-    public boolean saveDwarfData( DCPlayer dCPlayer, Skill[] skills )
+    public boolean saveDwarfData(DwarfPlayer dwarfPlayer, DwarfSkill[] skills )
     {
         try
         {
             PreparedStatement prep = mDBCon.prepareStatement( "UPDATE players SET race=? WHERE uuid=?;" );
-            prep.setString( 1, dCPlayer.getRace() );
-            prep.setString( 2, dCPlayer.getPlayer().getUniqueId().toString() );
+            prep.setString( 1, dwarfPlayer.getRace() );
+            prep.setString( 2, dwarfPlayer.getPlayer().getUniqueId().toString() );
             prep.execute();
             prep.close();
 
             prep = mDBCon.prepareStatement( "UPDATE players SET raceMaster=? WHERE uuid=?;" );
-            prep.setBoolean( 1, dCPlayer.isRaceMaster() );
-            prep.setString( 2, dCPlayer.getPlayer().getUniqueId().toString() );
+            prep.setBoolean( 1, dwarfPlayer.isRaceMaster() );
+            prep.setString( 2, dwarfPlayer.getPlayer().getUniqueId().toString() );
             prep.execute();
             prep.close();
 
             prep = mDBCon.prepareStatement( "REPLACE INTO skills(player, id, level, " + "deposit1, deposit2, deposit3) " + "values(?,?,?,?,?,?);" );
 
-            int id = getPlayerID( dCPlayer.getPlayer().getUniqueId() );
-            for ( Skill skill : skills )
+            int id = getPlayerID( dwarfPlayer.getPlayer().getUniqueId() );
+            for ( DwarfSkill skill : skills )
             {
                 prep.setInt( 1, id );
                 prep.setInt( 2, skill.getId() );

--- a/src/com/Jessy1237/DwarfCraft/DwarfCraft.java
+++ b/src/com/Jessy1237/DwarfCraft/DwarfCraft.java
@@ -24,12 +24,12 @@ import com.Jessy1237.DwarfCraft.commands.CommandSetSkill;
 import com.Jessy1237.DwarfCraft.commands.CommandSkillInfo;
 import com.Jessy1237.DwarfCraft.commands.CommandSkillSheet;
 import com.Jessy1237.DwarfCraft.commands.CommandTutorial;
-import com.Jessy1237.DwarfCraft.listeners.DCBlockListener;
-import com.Jessy1237.DwarfCraft.listeners.DCEntityListener;
-import com.Jessy1237.DwarfCraft.listeners.DCInventoryListener;
-import com.Jessy1237.DwarfCraft.listeners.DCListener;
-import com.Jessy1237.DwarfCraft.listeners.DCPlayerListener;
-import com.Jessy1237.DwarfCraft.listeners.DCVehicleListener;
+import com.Jessy1237.DwarfCraft.listeners.DwarfBlockListener;
+import com.Jessy1237.DwarfCraft.listeners.DwarfEntityListener;
+import com.Jessy1237.DwarfCraft.listeners.DwarfInventoryListener;
+import com.Jessy1237.DwarfCraft.listeners.DwarfListener;
+import com.Jessy1237.DwarfCraft.listeners.DwarfPlayerListener;
+import com.Jessy1237.DwarfCraft.listeners.DwarfVehicleListener;
 
 import de.diddiz.LogBlock.Consumer;
 import de.diddiz.LogBlock.LogBlock;
@@ -57,12 +57,12 @@ import net.milkbowl.vault.permission.Permission;
 public class DwarfCraft extends JavaPlugin
 {
 
-    private final DCBlockListener blockListener = new DCBlockListener( this );
-    private final DCPlayerListener playerListener = new DCPlayerListener( this );
-    private final DCEntityListener entityListener = new DCEntityListener( this );
-    private final DCVehicleListener vehicleListener = new DCVehicleListener( this );
-    private final DCInventoryListener inventoryListener = new DCInventoryListener( this );
-    private final DCListener dcListener = new DCListener( this );
+    private final DwarfBlockListener blockListener = new DwarfBlockListener( this );
+    private final DwarfPlayerListener playerListener = new DwarfPlayerListener( this );
+    private final DwarfEntityListener entityListener = new DwarfEntityListener( this );
+    private final DwarfVehicleListener vehicleListener = new DwarfVehicleListener( this );
+    private final DwarfInventoryListener inventoryListener = new DwarfInventoryListener( this );
+    private final DwarfListener dwarfListener = new DwarfListener( this );
     private NPCRegistry npcr;
     private ConfigManager cm;
     private DataManager dm;
@@ -105,12 +105,12 @@ public class DwarfCraft extends JavaPlugin
         return util;
     }
 
-    public DCEntityListener getDCEntityListener()
+    public DwarfEntityListener getDwarfEntityListener()
     {
         return entityListener;
     }
 
-    public DCInventoryListener getDCInventoryListener()
+    public DwarfInventoryListener getDwarfInventoryListener()
     {
         return inventoryListener;
     }
@@ -387,7 +387,7 @@ public class DwarfCraft extends JavaPlugin
 
         pm.registerEvents( inventoryListener, this );
 
-        pm.registerEvents( dcListener, this );
+        pm.registerEvents(dwarfListener, this );
 
         if ( pm.getPlugin( "Citizens" ) == null || pm.getPlugin( "Citizens" ).isEnabled() == false )
         {

--- a/src/com/Jessy1237/DwarfCraft/DwarfEffect.java
+++ b/src/com/Jessy1237/DwarfCraft/DwarfEffect.java
@@ -63,7 +63,7 @@ import org.jbls.LexManos.CSV.CSVRecord;
 import com.Jessy1237.DwarfCraft.events.DwarfCraftEffectEvent;
 
 @SuppressWarnings( "deprecation" )
-public class Effect
+public class DwarfEffect
 {
     private DwarfCraft plugin;
     private int mID;
@@ -86,7 +86,7 @@ public class Effect
 
     private EntityType mCreature;
 
-    public Effect( CSVRecord record, DwarfCraft plugin )
+    public DwarfEffect(CSVRecord record, DwarfCraft plugin )
     {
         if ( record == null )
             return;
@@ -132,7 +132,7 @@ public class Effect
      * 
      * @return
      */
-    protected String describeGeneral( DCPlayer dCPlayer )
+    protected String describeGeneral( DwarfPlayer dCPlayer )
     {
         String description;
         String initiator = plugin.getUtil().getCleanName( mInitiator );
@@ -164,7 +164,7 @@ public class Effect
      * @param dCPlayer
      * @return
      */
-    protected String describeLevel( DCPlayer dCPlayer )
+    protected String describeLevel( DwarfPlayer dCPlayer )
     {
         if ( dCPlayer == null )
             return "Failed"; // TODO add failure code
@@ -269,13 +269,13 @@ public class Effect
      * @param dCPlayer
      * @return
      */
-    public double getEffectAmount( DCPlayer dCPlayer )
+    public double getEffectAmount( DwarfPlayer dCPlayer )
     {
         return getEffectAmount( dCPlayer.getSkillLevel( this.mID / 10 ), dCPlayer );
     }
 
     @SuppressWarnings( "unlikely-arg-type" )
-    public double getEffectAmount( int skillLevel, DCPlayer dCPlayer )
+    public double getEffectAmount( int skillLevel, DwarfPlayer dCPlayer )
     {
         double effectAmount = mBase;
         if ( skillLevel == -1 )
@@ -327,17 +327,17 @@ public class Effect
         return mOutput;
     }
 
-    public ItemStack getOutput( DCPlayer player )
+    public ItemStack getOutput( DwarfPlayer player )
     {
         return getOutput( player, ( byte ) 0, -1 );
     }
 
-    public ItemStack getOutput( DCPlayer player, Byte oldData )
+    public ItemStack getOutput(DwarfPlayer player, Byte oldData )
     {
         return getOutput( player, oldData, -1 );
     }
 
-    public ItemStack getOutput( DCPlayer player, Byte oldData, int oldID )
+    public ItemStack getOutput(DwarfPlayer player, Byte oldData, int oldID )
     {
         Byte data = ( mOutput.getData() == null ? null : mOutput.getData().getData() );
 
@@ -555,12 +555,12 @@ public class Effect
         return Integer.toString( mID );
     }
 
-    public void damageTool( DCPlayer player, int base, ItemStack tool )
+    public void damageTool(DwarfPlayer player, int base, ItemStack tool )
     {
         damageTool( player, base, tool, true );
     }
 
-    public void damageTool( DCPlayer player, int base, ItemStack tool, boolean negate )
+    public void damageTool(DwarfPlayer player, int base, ItemStack tool, boolean negate )
     {
         short wear = ( short ) ( plugin.getUtil().randomAmount( getEffectAmount( player ) ) * base );
 

--- a/src/com/Jessy1237/DwarfCraft/DwarfPlayer.java
+++ b/src/com/Jessy1237/DwarfCraft/DwarfPlayer.java
@@ -13,10 +13,10 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-public class DCPlayer
+public class DwarfPlayer
 {
     private final DwarfCraft plugin;
-    private HashMap<Integer, Skill> skills;
+    private HashMap<Integer, DwarfSkill> skills;
     private Player player;
     private String race;
     private boolean raceMaster;
@@ -26,25 +26,25 @@ public class DCPlayer
         this.player = player;
     }
 
-    public DCPlayer( final DwarfCraft plugin, Player whoami )
+    public DwarfPlayer(final DwarfCraft plugin, Player player )
     {
         this.plugin = plugin;
-        this.player = whoami;
+        this.player = player;
         this.race = plugin.getConfigManager().getDefaultRace().trim();
         this.skills = plugin.getConfigManager().getAllSkills();
         this.raceMaster = false;
     }
 
-    public DCPlayer( final DwarfCraft plugin, Player whoami, String race, boolean raceMaster )
+    public DwarfPlayer(final DwarfCraft plugin, Player player, String race, boolean raceMaster )
     {
         this.plugin = plugin;
-        this.player = whoami;
+        this.player = player;
         this.race = race.trim();
         this.skills = plugin.getConfigManager().getAllSkills();
         this.raceMaster = raceMaster;
     }
 
-    public List<List<ItemStack>> calculateTrainingCost( Skill skill )
+    public List<List<ItemStack>> calculateTrainingCost( DwarfSkill skill )
     {
         int highSkills = countHighSkills();
         int dwarfLevel = getDwarfLevel();
@@ -60,7 +60,7 @@ public class DCPlayer
         // the skill is (what quartile)
         if ( DwarfCraft.debugMessagesThreshold < 0 )
             System.out.println( "DC0: starting skill ordering for quartiles" );
-        for ( Skill s : getSkills().values() )
+        for ( DwarfSkill s : getSkills().values() )
         {
             if ( s.getLevel() > plugin.getConfigManager().getRaceLevelLimit() )
             {
@@ -117,7 +117,7 @@ public class DCPlayer
     private int countHighSkills()
     {
         int highCount = 0;
-        for ( Skill s : getSkills().values() )
+        for ( DwarfSkill s : getSkills().values() )
         {
             if ( s.getLevel() > plugin.getConfigManager().getRaceLevelLimit() )
                 highCount++;
@@ -136,7 +136,7 @@ public class DCPlayer
     {
         int playerLevel = plugin.getConfigManager().getRaceLevelLimit();
         int highestSkill = 0;
-        for ( Skill s : getSkills().values() )
+        for ( DwarfSkill s : getSkills().values() )
         {
             if ( s.getLevel() > highestSkill )
                 highestSkill = s.getLevel();
@@ -155,10 +155,10 @@ public class DCPlayer
      * @param effectId
      * @return
      */
-    protected Effect getEffect( int effectId )
+    protected DwarfEffect getEffect(int effectId )
     {
-        Skill skill = getSkill( effectId / 10 );
-        for ( Effect effect : skill.getEffects() )
+        DwarfSkill skill = getSkill( effectId / 10 );
+        for ( DwarfEffect effect : skill.getEffects() )
         {
             if ( effect.getId() == effectId )
                 return effect;
@@ -176,11 +176,11 @@ public class DCPlayer
      * 
      * @param effect
      *            (does not have to be this dwarf's effect, only used for ID#)
-     * @return Skill or null if none found
+     * @return DwarfSkill or null if none found
      */
-    protected Skill getSkill( Effect effect )
+    protected DwarfSkill getSkill(DwarfEffect effect )
     {
-        for ( Skill skill : skills.values() )
+        for ( DwarfSkill skill : skills.values() )
         {
             if ( skill.getId() == effect.getId() / 10 )
                 return skill;
@@ -192,11 +192,11 @@ public class DCPlayer
      * Gets a dwarf's skill by id
      * 
      * @param skillId
-     * @return Skill or null if none found
+     * @return DwarfSkill or null if none found
      */
-    public Skill getSkill( int skillId )
+    public DwarfSkill getSkill(int skillId )
     {
-        Skill skill = skills.get( skillId );
+        DwarfSkill skill = skills.get( skillId );
         return skill;
     }
 
@@ -204,9 +204,9 @@ public class DCPlayer
      * Gets a dwarf's skill by name or id number(as String)
      * 
      * @param skillName
-     * @return Skill or null if none found
+     * @return DwarfSkill or null if none found
      */
-    protected Skill getSkill( String skillName )
+    protected DwarfSkill getSkill(String skillName )
     {
         try
         {
@@ -214,7 +214,7 @@ public class DCPlayer
         }
         catch ( NumberFormatException n )
         {
-            for ( Skill skill : getSkills().values() )
+            for ( DwarfSkill skill : getSkills().values() )
             {
                 if ( skill.getDisplayName() == null )
                     continue;
@@ -232,7 +232,7 @@ public class DCPlayer
         return null;
     }
 
-    public HashMap<Integer, Skill> getSkills()
+    public HashMap<Integer, DwarfSkill> getSkills()
     {
         return skills;
     }
@@ -246,7 +246,7 @@ public class DCPlayer
     {
         int playerLevel = plugin.getConfigManager().getRaceLevelLimit();
         int highestSkill = 0;
-        for ( Skill s : getSkills().values() )
+        for ( DwarfSkill s : getSkills().values() )
         {
             if ( s.getLevel() > highestSkill )
                 highestSkill = s.getLevel();
@@ -263,14 +263,14 @@ public class DCPlayer
      * @param skills
      *            the skills to set
      */
-    protected void setSkills( HashMap<Integer, Skill> skills )
+    protected void setSkills( HashMap<Integer, DwarfSkill> skills )
     {
         this.skills = skills;
     }
 
     public int getSkillLevel( int id )
     {
-        for ( Skill s : getSkills().values() )
+        for ( DwarfSkill s : getSkills().values() )
             if ( s.getId() == id )
                 return s.getLevel();
         return 0;
@@ -281,11 +281,11 @@ public class DCPlayer
         final String oldRace = this.race;
         this.race = race;
         skills = plugin.getConfigManager().getAllSkills();
-        Skill[] dCSkills = new Skill[skills.size()];
+        DwarfSkill[] dCSkills = new DwarfSkill[skills.size()];
 
         // Resets the players skills
         int I = 0;
-        for ( Skill skill : skills.values() )
+        for ( DwarfSkill skill : skills.values() )
         {
             skill.setLevel( 0 );
             skill.setDeposit1( 0 );

--- a/src/com/Jessy1237/DwarfCraft/DwarfRace.java
+++ b/src/com/Jessy1237/DwarfCraft/DwarfRace.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
  * Original Authors: smartaleq, LexManos and RCarretta
  */
 
-public class Race
+public class DwarfRace
 {
 
     private final String mName;
@@ -14,12 +14,12 @@ public class Race
     private String Desc;
     private String prefixColour;
 
-    public Race( String name )
+    public DwarfRace(String name )
     {
         this.mName = name;
     }
 
-    public Race( String name, final ArrayList<Integer> skills, String Desc )
+    public DwarfRace(String name, final ArrayList<Integer> skills, String Desc )
     {
         this.mName = name;
         this.Desc = Desc;

--- a/src/com/Jessy1237/DwarfCraft/DwarfSkill.java
+++ b/src/com/Jessy1237/DwarfCraft/DwarfSkill.java
@@ -8,13 +8,13 @@ import java.util.List;
 
 import org.bukkit.Material;
 
-public class Skill implements Cloneable
+public class DwarfSkill implements Cloneable
 {
 
     private final int mID;
     private final String mName;
     private int mLevel;
-    private final List<Effect> mEffects;
+    private final List<DwarfEffect> mEffects;
     private final Material mHeldItem;
     public final TrainingItem Item1;
     public final TrainingItem Item2;
@@ -23,7 +23,7 @@ public class Skill implements Cloneable
     private int deposit2;
     private int deposit3;
 
-    public Skill( int id, String displayName, int level, List<Effect> effects, TrainingItem item1, TrainingItem item2, TrainingItem item3, Material trainerHeldMaterial )
+    public DwarfSkill(int id, String displayName, int level, List<DwarfEffect> effects, TrainingItem item1, TrainingItem item2, TrainingItem item3, Material trainerHeldMaterial )
     {
         mID = id;
         mName = displayName;
@@ -45,10 +45,10 @@ public class Skill implements Cloneable
      * modified.
      */
     @Override
-    public Skill clone()
+    public DwarfSkill clone()
     {
 
-        Skill newSkill = new Skill( mID, mName, mLevel, mEffects, Item1, Item2, Item3, mHeldItem );
+        DwarfSkill newSkill = new DwarfSkill( mID, mName, mLevel, mEffects, Item1, Item2, Item3, mHeldItem );
         return newSkill;
     }
 
@@ -57,7 +57,7 @@ public class Skill implements Cloneable
         return mName;
     }
 
-    public List<Effect> getEffects()
+    public List<DwarfEffect> getEffects()
     {
         return mEffects;
     }

--- a/src/com/Jessy1237/DwarfCraft/DwarfTrainer.java
+++ b/src/com/Jessy1237/DwarfCraft/DwarfTrainer.java
@@ -7,6 +7,7 @@ package com.Jessy1237.DwarfCraft;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.Jessy1237.DwarfCraft.guis.TrainerGUI;
 import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
@@ -126,9 +127,9 @@ public final class DwarfTrainer
         return;
     }
 
-    public void depositOne( DCPlayer dCPlayer, ItemStack clickedItemStack, TrainerGUI trainerGUI )
+    public void depositOne(DwarfPlayer dCPlayer, ItemStack clickedItemStack, TrainerGUI trainerGUI )
     {
-        Skill skill = dCPlayer.getSkill( getSkillTrained() );
+        DwarfSkill skill = dCPlayer.getSkill( getSkillTrained() );
         final int dep1 = skill.getDeposit1(), dep2 = skill.getDeposit2(), dep3 = skill.getDeposit3();
         Player player = dCPlayer.getPlayer();
         List<List<ItemStack>> costs = dCPlayer.calculateTrainingCost( skill );
@@ -164,16 +165,16 @@ public final class DwarfTrainer
         if ( deposited )
         {
             plugin.getOut().sendMessage( player, Messages.depositSuccessful, tag );
-            Skill[] dCSkills = new Skill[1];
+            DwarfSkill[] dCSkills = new DwarfSkill[1];
             dCSkills[0] = skill;
             plugin.getDataManager().saveDwarfData( dCPlayer, dCSkills );
             player.getWorld().playSound( player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.MASTER, 1.0f, 1.0f );
         }
     }
 
-    public void depositAll( DCPlayer dCPlayer, ItemStack clickedItemStack, TrainerGUI trainerGUI )
+    public void depositAll(DwarfPlayer dCPlayer, ItemStack clickedItemStack, TrainerGUI trainerGUI )
     {
-        Skill skill = dCPlayer.getSkill( getSkillTrained() );
+        DwarfSkill skill = dCPlayer.getSkill( getSkillTrained() );
         final int dep1 = skill.getDeposit1(), dep2 = skill.getDeposit2(), dep3 = skill.getDeposit3();
         Player player = dCPlayer.getPlayer();
         List<List<ItemStack>> costs = dCPlayer.calculateTrainingCost( skill );
@@ -206,16 +207,16 @@ public final class DwarfTrainer
         if ( deposited )
         {
             plugin.getOut().sendMessage( player, Messages.depositSuccessful, tag );
-            Skill[] dCSkills = new Skill[1];
+            DwarfSkill[] dCSkills = new DwarfSkill[1];
             dCSkills[0] = skill;
             plugin.getDataManager().saveDwarfData( dCPlayer, dCSkills );
             player.getWorld().playSound( player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.MASTER, 1.0f, 1.0f );
         }
     }
 
-    public void trainSkill( DCPlayer dCPlayer, ItemStack clickedItemStack, TrainerGUI trainerGUI )
+    public void trainSkill(DwarfPlayer dCPlayer, ItemStack clickedItemStack, TrainerGUI trainerGUI )
     {
-        Skill skill = dCPlayer.getSkill( getSkillTrained() );
+        DwarfSkill skill = dCPlayer.getSkill( getSkillTrained() );
         Player player = dCPlayer.getPlayer();
         List<List<ItemStack>> costs = dCPlayer.calculateTrainingCost( skill );
         List<ItemStack> trainingCostsToLevel = costs.get( 0 );
@@ -265,7 +266,7 @@ public final class DwarfTrainer
                 }
             }
 
-            Skill[] dCSkills = new Skill[1];
+            DwarfSkill[] dCSkills = new DwarfSkill[1];
             dCSkills[0] = skill;
             plugin.getDataManager().saveDwarfData( dCPlayer, dCSkills );
             trainerGUI.updateTitle();
@@ -387,11 +388,11 @@ public final class DwarfTrainer
      * 
      * @param costStack The item type and amount to be removed
      * @param dCPlayer The player that is depositing
-     * @param trainerGUI The gui that flagged this deposit event
+     * @param trainerGUI The guis that flagged this deposit event
      * @param skill The skill that is being deposited into
      * @return True for [0] if the player had enough of the required item otherwise [0] false and True for [1] if any items were deposited into the skill otherwise false for [1]
      */
-    private boolean[] depositItem( ItemStack costStack, DCPlayer dCPlayer, TrainerGUI trainerGUI, Skill skill, String tag )
+    private boolean[] depositItem(ItemStack costStack, DwarfPlayer dCPlayer, TrainerGUI trainerGUI, DwarfSkill skill, String tag )
     {
         boolean[] hasMatsOrDeposits = { true, false };
         final int origCost = costStack.getAmount();

--- a/src/com/Jessy1237/DwarfCraft/DwarfTrainerTrait.java
+++ b/src/com/Jessy1237/DwarfCraft/DwarfTrainerTrait.java
@@ -76,7 +76,7 @@ public class DwarfTrainerTrait extends Trait
     {
         if ( event.getNPC().hasTrait( DwarfTrainerTrait.class ) && event.getNPC().getId() == getNPC().getId() )
         {
-            plugin.getDCEntityListener().onNPCLeftClickEvent( event );
+            plugin.getDwarfEntityListener().onNPCLeftClickEvent( event );
         }
     }
 
@@ -85,7 +85,7 @@ public class DwarfTrainerTrait extends Trait
     {
         if ( event.getNPC().hasTrait( DwarfTrainerTrait.class ) && event.getNPC().getId() == getNPC().getId() )
         {
-            plugin.getDCEntityListener().onNPCRightClickEvent( event );
+            plugin.getDwarfEntityListener().onNPCRightClickEvent( event );
         }
     }
 

--- a/src/com/Jessy1237/DwarfCraft/Messages.java
+++ b/src/com/Jessy1237/DwarfCraft/Messages.java
@@ -84,9 +84,9 @@ public final class Messages
     public static String moreItemNeeded = "&cAn additional &2%costamount% %itemname% &cis required";
     public static String trainingSuccessful = "&6Training Successful!";
     public static String depositSuccessful = "&6Deposit Successful!";
-    public static String trainerGUITitle = "&6Training: &b%skillname%&6 [&b%skillid%&6] || &3%skilllevel%/%maxskilllevel%";
+    public static String trainerGUITitle = "&5Training: &4%skillname%&3 || &9%skilllevel%/%maxskilllevel%";
     public static String trainerOccupied = "&6Please wait. I am talking to someone else.";
-    public static String trainerCooldown = "&6Sorry, i need time to recuperate.";
+    public static String trainerCooldown = "&6Sorry, I need time to recuperate.";
     public static String describeGeneral = "Effect Block Trigger: %initiator% Block Output: %output%. Effect value ranges from %effectamountlow% - %effectamounthigh% for levels 0 to 30. Non specialists have the effect %minoramount% , as if they were level %normallevel%. Tools affected: %tooltype%.";
     public static String describeLevelBlockdrop = "&6Break a &2%initiator% &6and %effectlevelcolor%%effectamount% &2%output%&6 are created";
     public static String describeLevelMobdrop = "&6%creaturename% drop about %effectlevelcolor%%effectamount% &2%output%";

--- a/src/com/Jessy1237/DwarfCraft/Out.java
+++ b/src/com/Jessy1237/DwarfCraft/Out.java
@@ -36,7 +36,7 @@ public class Out
         return null;
     }
 
-    public boolean effectInfo( CommandSender sender, DCPlayer dCPlayer, Effect effect )
+    public boolean effectInfo( CommandSender sender, DwarfPlayer dCPlayer, DwarfEffect effect )
     {
         String prefix = Messages.effectInfoPrefix;
         prefix = prefix.replaceAll( "%effectid%", "" + effect.getId() );
@@ -113,7 +113,7 @@ public class Out
         return lastColor = lastColor( lastColor + currentLine );
     }
 
-    public boolean printSkillInfo( CommandSender sender, Skill skill, DCPlayer dCPlayer, int maxTrainLevel )
+    public boolean printSkillInfo( CommandSender sender, DwarfSkill skill, DwarfPlayer dCPlayer, int maxTrainLevel )
     {
         // general line
         sendMessage( sender, Messages.skillInfoHeader.replaceAll( "%playername%", dCPlayer.getPlayer().getDisplayName() ).replaceAll( "%skillid%", "" + skill.getId() ).replaceAll( "%skillname%", "" + skill.getDisplayName() ).replaceAll( "%skilllevel%", "" + skill.getLevel() )
@@ -121,7 +121,7 @@ public class Out
 
         // effects lines
         sendMessage( sender, Messages.skillInfoMinorHeader );
-        for ( Effect effect : skill.getEffects() )
+        for ( DwarfEffect effect : skill.getEffects() )
         {
             if ( effect != null )
                 sendMessage( sender, effect.describeLevel( dCPlayer ), Messages.skillInfoEffectIDPrefix.replaceAll( "%effectid%", "" + effect.getId() ) );
@@ -159,7 +159,7 @@ public class Out
         return true;
     }
 
-    public void printSkillSheet( DCPlayer dCPlayer, CommandSender sender, String displayName, boolean printFull )
+    public void printSkillSheet( DwarfPlayer dCPlayer, CommandSender sender, String displayName, boolean printFull )
     {
         String message1;
         String message2 = "";
@@ -170,7 +170,7 @@ public class Out
 
         boolean odd = true;
         String untrainedSkills = Messages.skillSheetUntrainedSkillHeader;
-        for ( Skill s : dCPlayer.getSkills().values() )
+        for ( DwarfSkill s : dCPlayer.getSkills().values() )
         {
             if ( s.getLevel() == 0 )
             {
@@ -266,7 +266,7 @@ public class Out
         }
     }
 
-    protected void sendMessage( DCPlayer dCPlayer, String message )
+    protected void sendMessage( DwarfPlayer dCPlayer, String message )
     {
         sendMessage( dCPlayer.getPlayer(), message );
     }
@@ -329,7 +329,7 @@ public class Out
      *
      * @param dCPlayer
      */
-    public void welcome( DCPlayer dCPlayer )
+    public void welcome( DwarfPlayer dCPlayer )
     {
         try
         {
@@ -352,32 +352,32 @@ public class Out
         sendMessage( sender, parseRace( Messages.adminRaceCheck, plugin.getDataManager().find( player ), null ) );
     }
 
-    public void alreadyRace( CommandSender sender, DCPlayer dCPlayer, String newRace )
+    public void alreadyRace( CommandSender sender, DwarfPlayer dCPlayer, String newRace )
     {
         sendMessage( sender, parseRace( Messages.alreadyRace, dCPlayer, newRace ) );
     }
 
-    public void resetRace( CommandSender sender, DCPlayer dCPlayer, String newRace )
+    public void resetRace( CommandSender sender, DwarfPlayer dCPlayer, String newRace )
     {
         sendMessage( sender, parseRace( Messages.resetRace, dCPlayer, newRace ) );
     }
 
-    public void changedRace( CommandSender sender, DCPlayer dCPlayer, String newRace )
+    public void changedRace( CommandSender sender, DwarfPlayer dCPlayer, String newRace )
     {
         sendMessage( sender, parseRace( Messages.changedRace, dCPlayer, newRace ) );
     }
 
-    public void confirmRace( CommandSender sender, DCPlayer dCPlayer, String newRace )
+    public void confirmRace( CommandSender sender, DwarfPlayer dCPlayer, String newRace )
     {
         sendMessage( sender, parseRace( Messages.confirmRace, dCPlayer, newRace ) );
     }
 
-    public void dExistRace( CommandSender sender, DCPlayer dCPlayer, String newRace )
+    public void dExistRace( CommandSender sender, DwarfPlayer dCPlayer, String newRace )
     {
         sendMessage( sender, parseRace( Messages.raceDoesNotExist, dCPlayer, newRace ) );
     }
 
-    public String parseRace( String message, DCPlayer dCPlayer, String newRace )
+    public String parseRace( String message, DwarfPlayer dCPlayer, String newRace )
     {
         String out = message;
 
@@ -389,7 +389,7 @@ public class Out
         return out;
     }
 
-    public String parseSkillSheet( String message, DCPlayer dCPlayer, String displayName, Skill skill )
+    public String parseSkillSheet( String message, DwarfPlayer dCPlayer, String displayName, DwarfSkill skill )
     {
         String out = message.replace( "%playername%", ( displayName == null ? dCPlayer.getPlayer().getName() : displayName ) );
         out = out.replaceAll( "%playerrace%", dCPlayer.getRace() );
@@ -403,7 +403,7 @@ public class Out
     }
 
     @SuppressWarnings( "deprecation" )
-    public String parseEffectLevel( EffectType type, String initiator, String output, double effectAmount, double minorAmount, boolean moreThanOne, String effectLevelColor, String toolType, EntityType creature, DCPlayer dCPlayer, ItemStack mInitiator )
+    public String parseEffectLevel( EffectType type, String initiator, String output, double effectAmount, double minorAmount, boolean moreThanOne, String effectLevelColor, String toolType, EntityType creature, DwarfPlayer dCPlayer, ItemStack mInitiator )
     {
         String out = "";
 

--- a/src/com/Jessy1237/DwarfCraft/TrainSkillSchedule.java
+++ b/src/com/Jessy1237/DwarfCraft/TrainSkillSchedule.java
@@ -1,5 +1,6 @@
 package com.Jessy1237.DwarfCraft;
 
+import com.Jessy1237.DwarfCraft.guis.TrainerGUI;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -8,11 +9,11 @@ public class TrainSkillSchedule implements Runnable
 
     private DwarfCraft plugin;
     private final DwarfTrainer trainer;
-    private final DCPlayer dCPlayer;
+    private final DwarfPlayer dCPlayer;
     private final ItemStack clickedItem;
     private final TrainerGUI trainerGUI;
 
-    public TrainSkillSchedule( DwarfCraft plugin, DwarfTrainer trainer, DCPlayer dCPlayer, ItemStack clickedItem, TrainerGUI trainerGUI )
+    public TrainSkillSchedule(DwarfCraft plugin, DwarfTrainer trainer, DwarfPlayer dCPlayer, ItemStack clickedItem, TrainerGUI trainerGUI )
     {
         this.plugin = plugin;
         this.trainer = trainer;
@@ -25,7 +26,7 @@ public class TrainSkillSchedule implements Runnable
     public void run()
     {
 
-        Skill skill = dCPlayer.getSkill( trainer.getSkillTrained() );
+        DwarfSkill skill = dCPlayer.getSkill( trainer.getSkillTrained() );
         String tag = Messages.trainSkillPrefix.replaceAll( "%skillid%", "" + skill.getId() );
 
         if ( clickedItem.getType().equals( Material.INK_SACK ) )

--- a/src/com/Jessy1237/DwarfCraft/Util.java
+++ b/src/com/Jessy1237/DwarfCraft/Util.java
@@ -431,7 +431,7 @@ public class Util
         return null;
     }
 
-    public String getPlayerPrefix( DCPlayer player )
+    public String getPlayerPrefix( DwarfPlayer player )
     {
         String race = player.getRace().substring( 0, 1 ).toUpperCase() + player.getRace().substring( 1 );
         return plugin.getOut().parseColors( plugin.getConfigManager().getRace( race ).getPrefixColour() + plugin.getConfigManager().getPrefix().replace( "%racename%", race ) + "&f" );
@@ -459,7 +459,7 @@ public class Util
             {
                 for ( World w : plugin.getServer().getWorlds() )
                 {
-                    for ( Race race : plugin.getConfigManager().getRaceList() )
+                    for ( DwarfRace race : plugin.getConfigManager().getRaceList() )
                     {
                         String raceStr = race.getName();
                         while ( plugin.getChat().getPlayerPrefix( w.getName(), op ).contains( getPlayerPrefix( raceStr ) ) )
@@ -484,7 +484,7 @@ public class Util
     public void setPlayerPrefix( Player player )
     {
         DataManager dm = plugin.getDataManager();
-        DCPlayer data = dm.find( player );
+        DwarfPlayer data = dm.find( player );
 
         if ( data == null )
             data = dm.createDwarf( player );

--- a/src/com/Jessy1237/DwarfCraft/commands/CommandCreateTrainer.java
+++ b/src/com/Jessy1237/DwarfCraft/commands/CommandCreateTrainer.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import com.Jessy1237.DwarfCraft.*;
 import net.citizensnpcs.api.npc.AbstractNPC;
 
 import org.bukkit.command.Command;
@@ -15,13 +16,8 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 
-import com.Jessy1237.DwarfCraft.CommandInformation;
-import com.Jessy1237.DwarfCraft.CommandParser;
-import com.Jessy1237.DwarfCraft.DCCommandException;
 import com.Jessy1237.DwarfCraft.DCCommandException.Type;
-import com.Jessy1237.DwarfCraft.DwarfCraft;
-import com.Jessy1237.DwarfCraft.DwarfTrainerTrait;
-import com.Jessy1237.DwarfCraft.Skill;
+import com.Jessy1237.DwarfCraft.DwarfSkill;
 
 public class CommandCreateTrainer extends Command
 {
@@ -58,7 +54,7 @@ public class CommandCreateTrainer extends Command
 
                 String uniqueId = "UniqueIdAdd";
                 String name = "Name";
-                Skill skill = new Skill( 0, null, 0, null, null, null, null, null );
+                DwarfSkill skill = new DwarfSkill( 0, null, 0, null, null, null, null, null );
                 Integer maxSkill = 1;
                 Integer minSkill = 1;
                 String type = "Type";
@@ -75,7 +71,7 @@ public class CommandCreateTrainer extends Command
                     outputList = parser.parse( desiredArguments, false );
                     uniqueId = ( String ) outputList.get( 0 );
                     name = ( String ) outputList.get( 1 );
-                    skill = ( Skill ) outputList.get( 2 );
+                    skill = (DwarfSkill) outputList.get( 2 );
                     maxSkill = ( Integer ) outputList.get( 3 );
                     minSkill = ( Integer ) outputList.get( 4 );
                     type = ( String ) outputList.get( 5 );
@@ -87,7 +83,7 @@ public class CommandCreateTrainer extends Command
                         outputList = parser.parse( desiredArguments, true );
                         uniqueId = ( String ) outputList.get( 0 );
                         name = ( String ) outputList.get( 1 );
-                        skill = ( Skill ) outputList.get( 2 );
+                        skill = (DwarfSkill) outputList.get( 2 );
                         maxSkill = ( Integer ) outputList.get( 3 );
                         minSkill = ( Integer ) outputList.get( 4 );
                         type = ( String ) outputList.get( 5 );

--- a/src/com/Jessy1237/DwarfCraft/commands/CommandEffectInfo.java
+++ b/src/com/Jessy1237/DwarfCraft/commands/CommandEffectInfo.java
@@ -7,16 +7,12 @@ package com.Jessy1237.DwarfCraft.commands;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.Jessy1237.DwarfCraft.*;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 
-import com.Jessy1237.DwarfCraft.CommandInformation;
-import com.Jessy1237.DwarfCraft.CommandParser;
-import com.Jessy1237.DwarfCraft.DCCommandException;
 import com.Jessy1237.DwarfCraft.DCCommandException.Type;
-import com.Jessy1237.DwarfCraft.DCPlayer;
-import com.Jessy1237.DwarfCraft.DwarfCraft;
-import com.Jessy1237.DwarfCraft.Effect;
+import com.Jessy1237.DwarfCraft.DwarfPlayer;
 
 public class CommandEffectInfo extends Command
 {
@@ -50,15 +46,15 @@ public class CommandEffectInfo extends Command
                 List<Object> desiredArguments = new ArrayList<Object>();
                 List<Object> outputList = null;
 
-                DCPlayer dCPlayer = new DCPlayer( plugin, null );
-                Effect effect = new Effect( null, plugin );
+                DwarfPlayer dCPlayer = new DwarfPlayer( plugin, null );
+                DwarfEffect effect = new DwarfEffect( null, plugin );
                 desiredArguments.add( dCPlayer );
                 desiredArguments.add( effect );
                 try
                 {
                     outputList = parser.parse( desiredArguments, false );
-                    effect = ( Effect ) outputList.get( 1 );
-                    dCPlayer = ( DCPlayer ) outputList.get( 0 );
+                    effect = ( DwarfEffect ) outputList.get( 1 );
+                    dCPlayer = ( DwarfPlayer ) outputList.get( 0 );
                 }
                 catch ( DCCommandException dce )
                 {
@@ -67,8 +63,8 @@ public class CommandEffectInfo extends Command
                         desiredArguments.remove( 0 );
                         desiredArguments.add( dCPlayer );
                         outputList = parser.parse( desiredArguments, true );
-                        effect = ( Effect ) outputList.get( 0 );
-                        dCPlayer = ( DCPlayer ) outputList.get( 1 );
+                        effect = ( DwarfEffect ) outputList.get( 0 );
+                        dCPlayer = ( DwarfPlayer ) outputList.get( 1 );
                     }
                     else
                         throw dce;

--- a/src/com/Jessy1237/DwarfCraft/commands/CommandListTrainers.java
+++ b/src/com/Jessy1237/DwarfCraft/commands/CommandListTrainers.java
@@ -6,13 +6,17 @@ package com.Jessy1237.DwarfCraft.commands;
 
 import java.util.Collection;
 
+import com.Jessy1237.DwarfCraft.DwarfPlayer;
+import com.Jessy1237.DwarfCraft.DwarfSkill;
+import com.Jessy1237.DwarfCraft.guis.ListTrainersGUI;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 
 import com.Jessy1237.DwarfCraft.DwarfCraft;
 import com.Jessy1237.DwarfCraft.DwarfTrainer;
-import com.Jessy1237.DwarfCraft.Skill;
+import org.bukkit.entity.Player;
 
 public class CommandListTrainers extends Command
 {
@@ -28,61 +32,77 @@ public class CommandListTrainers extends Command
     public boolean execute( CommandSender sender, String commandLabel, String[] args )
     {
         if ( DwarfCraft.debugMessagesThreshold < 1 )
-            System.out.println( "DC1: started command 'listtrainers'" );
+            System.out.println("DC1: started command 'list_trainers'");
 
         int page = 1;
-        if ( args.length > 0 )
-        {
-            try
-            {
-                Integer.parseInt( args[0] );
-            }
-            catch ( NumberFormatException e )
-            {
-                page = 1;
-            }
-        }
+
         Collection<DwarfTrainer> col = plugin.getDataManager().trainerList.values();
         DwarfTrainer[] trainers = new DwarfTrainer[col.size()];
-        col.toArray( trainers );
+        col.toArray(trainers);
 
-        if ( trainers.length == 0 )
-        {
-            sender.sendMessage( "There are currently no trainers." );
+        if (sender instanceof Player) {
+            // Use GUI implementation
+            System.out.println("Calling Trainer List GUI");
+
+            //TODO: Support paging to allow more than 54 trainers
+            //HACK: DONT HARDCODE VALUES HERE
+            if (trainers.length > 54) {
+                sender.sendMessage(ChatColor.DARK_RED + "Error: More than 54 trainers is not supported at this time...");
+                return true;
+            }
+
+            DwarfPlayer dwarfPlayer = new DwarfPlayer(plugin, (Player)sender);
+
+            ListTrainersGUI listTrainersGUI = new ListTrainersGUI(plugin, dwarfPlayer);
+            listTrainersGUI.init();
+            listTrainersGUI.openGUI();
+
+            plugin.getDwarfInventoryListener().listTrainersGUI.put(dwarfPlayer.getPlayer(), listTrainersGUI);
+
+            return true;
+        } else {
+            if (args.length > 0) {
+                try {
+                    Integer.parseInt(args[0]);
+                } catch (NumberFormatException e) {
+                    page = 1;
+                }
+            }
+
+            if (trainers.length == 0) {
+                sender.sendMessage("There are currently no trainers.");
+                return true;
+            }
+
+            int maxpage = (int) Math.ceil(trainers.length / 10.0);
+            Collection<DwarfSkill> skills = plugin.getConfigManager().getAllSkills().values();
+
+            page = Math.min(page, maxpage);
+            page = Math.max(page, 1);
+
+            int idx = (page - 1) * 10;
+            sender.sendMessage(String.format("Trainers page %d/%d", page, maxpage));
+
+            for (int x = 0; x < 10; x++) {
+                if (idx + x >= trainers.length)
+                    return true;
+
+                DwarfTrainer trainer = trainers[idx + x];
+                Location loc = trainer.getLocation();
+
+                if (trainer.isGreeter()) {
+                    sender.sendMessage( String.format("Greeter ID: %s Name: %s (%d, %d, %d)", trainer.getUniqueId(), trainer.getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()) );
+                } else {
+                    String skillName = "Unknown";
+                    for (DwarfSkill skill : skills) {
+                        if (skill.getId() == trainer.getSkillTrained())
+                            skillName = skill.getDisplayName();
+                    }
+                    sender.sendMessage( String.format("Trainer ID: %s Name: %s Trains: %d %s (%d, %d, %d)", trainer.getUniqueId(), trainer.getName(), trainer.getMaxSkill(), skillName, loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()) );
+                }
+            }
             return true;
         }
-        int maxpage = ( int ) Math.ceil( trainers.length / 10.0 );
-        Collection<Skill> skills = plugin.getConfigManager().getAllSkills().values();
-
-        page = Math.min( page, maxpage );
-        page = Math.max( page, 1 );
-
-        int idx = ( page - 1 ) * 10;
-        sender.sendMessage( String.format( "Trainers page %d/%d", page, maxpage ) );
-
-        for ( int x = 0; x < 10; x++ )
-        {
-            if ( idx + x >= trainers.length )
-                return true;
-
-            DwarfTrainer trainer = trainers[idx + x];
-            Location loc = trainer.getLocation();
-
-            if ( trainer.isGreeter() )
-            {
-                sender.sendMessage( String.format( "Greeter ID: %s Name: %s (%d, %d, %d)", trainer.getUniqueId(), trainer.getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ() ) );
-            }
-            else
-            {
-                String skillName = "Unknown";
-                for ( Skill skill : skills )
-                {
-                    if ( skill.getId() == trainer.getSkillTrained() )
-                        skillName = skill.getDisplayName();
-                }
-                sender.sendMessage( String.format( "Trainer ID: %s Name: %s Trains: %d %s (%d, %d, %d)", trainer.getUniqueId(), trainer.getName(), trainer.getMaxSkill(), skillName, loc.getBlockX(), loc.getBlockY(), loc.getBlockZ() ) );
-            }
-        }
-        return true;
     }
+
 }

--- a/src/com/Jessy1237/DwarfCraft/commands/CommandRace.java
+++ b/src/com/Jessy1237/DwarfCraft/commands/CommandRace.java
@@ -4,12 +4,13 @@ package com.Jessy1237.DwarfCraft.commands;
  * Original Authors: smartaleq, LexManos and RCarretta
  */
 
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import com.Jessy1237.DwarfCraft.CommandInformation;
-import com.Jessy1237.DwarfCraft.DCPlayer;
+import com.Jessy1237.DwarfCraft.DwarfPlayer;
 import com.Jessy1237.DwarfCraft.DwarfCraft;
 import com.Jessy1237.DwarfCraft.events.DwarfCraftRaceChangeEvent;
 
@@ -19,7 +20,7 @@ public class CommandRace extends Command
 
     public CommandRace( final DwarfCraft plugin )
     {
-        super( "Race" );
+        super( "DwarfRace" );
         this.plugin = plugin;
     }
 
@@ -58,7 +59,7 @@ public class CommandRace extends Command
             String newRace = args[1];
             String name = args[0];
             Player p = plugin.getServer().getPlayer( args[0] );
-            DCPlayer dCPlayer = null;
+            DwarfPlayer dCPlayer = null;
             if ( p == null )
             {
                 plugin.getOut().sendMessage( sender, "Not a valid Player Name." );
@@ -91,7 +92,7 @@ public class CommandRace extends Command
         else
         {
             String newRace = args[0];
-            DCPlayer dCPlayer = plugin.getDataManager().find( ( Player ) sender );
+            DwarfPlayer dCPlayer = plugin.getDataManager().find( ( Player ) sender );
             boolean confirmed = false;
             if ( args[1] != null )
             {
@@ -105,7 +106,7 @@ public class CommandRace extends Command
         return true;
     }
 
-    private void race( String newRace, boolean confirm, DCPlayer dCPlayer, CommandSender sender )
+    private void race(String newRace, boolean confirm, DwarfPlayer dCPlayer, CommandSender sender )
     {
         if ( dCPlayer.getRace() == newRace )
         {
@@ -132,7 +133,7 @@ public class CommandRace extends Command
                         }
                         else
                         {
-                            sender.sendMessage( "§4You do not have permission to do that." );
+                            sender.sendMessage(ChatColor.DARK_RED + "You do not have permission to do that." );
                         }
                     }
                     else

--- a/src/com/Jessy1237/DwarfCraft/commands/CommandRaces.java
+++ b/src/com/Jessy1237/DwarfCraft/commands/CommandRaces.java
@@ -1,10 +1,10 @@
 package com.Jessy1237.DwarfCraft.commands;
 
+import com.Jessy1237.DwarfCraft.DwarfRace;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 
 import com.Jessy1237.DwarfCraft.DwarfCraft;
-import com.Jessy1237.DwarfCraft.Race;
 
 /**
  * Original Authors: Jessy1237
@@ -25,7 +25,7 @@ public class CommandRaces extends Command
     public boolean execute( CommandSender sender, String commandLabel, String[] args )
     {
         plugin.getOut().sendMessage( sender, "&7Races:&f" );
-        for ( Race r : plugin.getConfigManager().getRaceList() )
+        for ( DwarfRace r : plugin.getConfigManager().getRaceList() )
         {
             if ( r != null )
             {

--- a/src/com/Jessy1237/DwarfCraft/commands/CommandSetSkill.java
+++ b/src/com/Jessy1237/DwarfCraft/commands/CommandSetSkill.java
@@ -7,17 +7,13 @@ package com.Jessy1237.DwarfCraft.commands;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.Jessy1237.DwarfCraft.*;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import com.Jessy1237.DwarfCraft.CommandInformation;
-import com.Jessy1237.DwarfCraft.CommandParser;
-import com.Jessy1237.DwarfCraft.DCCommandException;
 import com.Jessy1237.DwarfCraft.DCCommandException.Type;
-import com.Jessy1237.DwarfCraft.DCPlayer;
-import com.Jessy1237.DwarfCraft.DwarfCraft;
-import com.Jessy1237.DwarfCraft.Skill;
+import com.Jessy1237.DwarfCraft.DwarfPlayer;
 import com.Jessy1237.DwarfCraft.events.DwarfCraftLevelUpEvent;
 
 public class CommandSetSkill extends Command
@@ -52,8 +48,8 @@ public class CommandSetSkill extends Command
                 List<Object> desiredArguments = new ArrayList<Object>();
                 List<Object> outputList = null;
 
-                DCPlayer dCPlayer = new DCPlayer( plugin, null );
-                Skill skill = new Skill( 0, null, 0, null, null, null, null, null );
+                DwarfPlayer dCPlayer = new DwarfPlayer( plugin, null );
+                DwarfSkill skill = new DwarfSkill( 0, null, 0, null, null, null, null, null );
                 int level = 0;
                 String name;
                 desiredArguments.add( dCPlayer );
@@ -63,8 +59,8 @@ public class CommandSetSkill extends Command
                 try
                 {
                     outputList = parser.parse( desiredArguments, false );
-                    dCPlayer = ( DCPlayer ) outputList.get( 0 );
-                    skill = ( Skill ) outputList.get( 1 );
+                    dCPlayer = (DwarfPlayer) outputList.get( 0 );
+                    skill = (DwarfSkill) outputList.get( 1 );
                     level = ( Integer ) outputList.get( 2 );
                     name = dCPlayer.getPlayer().getName();
                 }
@@ -77,8 +73,8 @@ public class CommandSetSkill extends Command
                             desiredArguments.remove( 0 );
                             desiredArguments.add( dCPlayer );
                             outputList = parser.parse( desiredArguments, true );
-                            dCPlayer = ( DCPlayer ) outputList.get( 2 );
-                            skill = ( Skill ) outputList.get( 0 );
+                            dCPlayer = (DwarfPlayer) outputList.get( 2 );
+                            skill = (DwarfSkill) outputList.get( 0 );
                             level = ( Integer ) outputList.get( 1 );
                             name = ( ( Player ) sender ).getName();
                         }
@@ -90,9 +86,9 @@ public class CommandSetSkill extends Command
                 }
                 if ( skill == null )
                 {
-                    Skill[] skills = new Skill[dCPlayer.getSkills().values().size()];
+                    DwarfSkill[] skills = new DwarfSkill[dCPlayer.getSkills().values().size()];
                     int i = 0;
-                    for ( Skill s : dCPlayer.getSkills().values() )
+                    for ( DwarfSkill s : dCPlayer.getSkills().values() )
                     {
                         int oldLevel = s.getLevel();
                         s.setLevel( level );
@@ -125,7 +121,7 @@ public class CommandSetSkill extends Command
                         skill.setDeposit1( 0 );
                         skill.setDeposit2( 0 );
                         skill.setDeposit3( 0 );
-                        Skill[] skills = new Skill[1];
+                        DwarfSkill[] skills = new DwarfSkill[1];
                         skills[0] = skill;
                         plugin.getOut().sendMessage( sender, "&aAdmin: &eset skill &b" + skill.getDisplayName() + "&e for player &9" + name + "&e to &3" + level );
                         plugin.getDataManager().saveDwarfData( dCPlayer, skills );

--- a/src/com/Jessy1237/DwarfCraft/commands/CommandSkillInfo.java
+++ b/src/com/Jessy1237/DwarfCraft/commands/CommandSkillInfo.java
@@ -7,17 +7,13 @@ package com.Jessy1237.DwarfCraft.commands;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.Jessy1237.DwarfCraft.*;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import com.Jessy1237.DwarfCraft.CommandInformation;
-import com.Jessy1237.DwarfCraft.CommandParser;
-import com.Jessy1237.DwarfCraft.DCCommandException;
 import com.Jessy1237.DwarfCraft.DCCommandException.Type;
-import com.Jessy1237.DwarfCraft.DCPlayer;
-import com.Jessy1237.DwarfCraft.DwarfCraft;
-import com.Jessy1237.DwarfCraft.Skill;
+import com.Jessy1237.DwarfCraft.DwarfPlayer;
 
 public class CommandSkillInfo extends Command
 {
@@ -51,9 +47,9 @@ public class CommandSkillInfo extends Command
                 List<Object> desiredArguments = new ArrayList<Object>();
                 List<Object> outputList = null;
 
-                DCPlayer dCPlayer = new DCPlayer( plugin, null );
-                Skill skill = new Skill( 0, null, 0, null, null, null, null, null );
-                desiredArguments.add( dCPlayer );
+                DwarfPlayer dwarfPlayer = new DwarfPlayer( plugin, null );
+                DwarfSkill skill = new DwarfSkill( 0, null, 0, null, null, null, null, null );
+                desiredArguments.add( dwarfPlayer );
                 desiredArguments.add( skill );
 
                 try
@@ -62,8 +58,8 @@ public class CommandSkillInfo extends Command
                     if ( args.length > outputList.size() )
                         throw new DCCommandException( plugin, Type.TOOMANYARGS );
 
-                    skill = ( Skill ) outputList.get( 1 );
-                    dCPlayer = ( DCPlayer ) outputList.get( 0 );
+                    skill = (DwarfSkill) outputList.get( 1 );
+                    dwarfPlayer = (DwarfPlayer) outputList.get( 0 );
                 }
                 catch ( DCCommandException dce )
                 {
@@ -71,15 +67,15 @@ public class CommandSkillInfo extends Command
                     {
                         desiredArguments.remove( 0 );
                         outputList = parser.parse( desiredArguments, true );
-                        skill = ( Skill ) outputList.get( 0 );
+                        skill = (DwarfSkill) outputList.get( 0 );
                         if ( !( sender instanceof Player ) )
                             throw new DCCommandException( plugin, Type.CONSOLECANNOTUSE );
-                        dCPlayer = plugin.getDataManager().find( ( Player ) sender );
+                        dwarfPlayer = plugin.getDataManager().find( ( Player ) sender );
                     }
                     else
                         throw dce;
                 }
-                plugin.getOut().printSkillInfo( sender, skill, dCPlayer, 30 );
+                plugin.getOut().printSkillInfo( sender, skill, dwarfPlayer, 30 );
                 return true;
 
             }

--- a/src/com/Jessy1237/DwarfCraft/commands/CommandSkillSheet.java
+++ b/src/com/Jessy1237/DwarfCraft/commands/CommandSkillSheet.java
@@ -7,16 +7,13 @@ package com.Jessy1237.DwarfCraft.commands;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.Jessy1237.DwarfCraft.*;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import com.Jessy1237.DwarfCraft.CommandInformation;
-import com.Jessy1237.DwarfCraft.CommandParser;
-import com.Jessy1237.DwarfCraft.DCCommandException;
 import com.Jessy1237.DwarfCraft.DCCommandException.Type;
-import com.Jessy1237.DwarfCraft.DCPlayer;
-import com.Jessy1237.DwarfCraft.DwarfCraft;
+import com.Jessy1237.DwarfCraft.DwarfPlayer;
 
 public class CommandSkillSheet extends Command
 {
@@ -59,7 +56,7 @@ public class CommandSkillSheet extends Command
                 desiredArguments.add( args[0] );
             }
 
-            DCPlayer dCPlayer = new DCPlayer( plugin, null );
+            DwarfPlayer dCPlayer = new DwarfPlayer( plugin, null );
             desiredArguments.add( dCPlayer );
             String displayName = null;
 
@@ -67,9 +64,9 @@ public class CommandSkillSheet extends Command
             {
                 outputList = parser.parse( desiredArguments, false );
                 if ( outputList.get( 0 ) instanceof String )
-                    dCPlayer = ( DCPlayer ) outputList.get( 1 );
+                    dCPlayer = (DwarfPlayer) outputList.get( 1 );
                 else
-                    dCPlayer = ( DCPlayer ) outputList.get( 0 );
+                    dCPlayer = (DwarfPlayer) outputList.get( 0 );
                 if ( dCPlayer.getPlayer() == null )
                     displayName = ( printFull ? args[1] : args[0] );
                 else

--- a/src/com/Jessy1237/DwarfCraft/events/DwarfCraftDepositEvent.java
+++ b/src/com/Jessy1237/DwarfCraft/events/DwarfCraftDepositEvent.java
@@ -1,21 +1,21 @@
 package com.Jessy1237.DwarfCraft.events;
 
+import com.Jessy1237.DwarfCraft.DwarfSkill;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
-import com.Jessy1237.DwarfCraft.DCPlayer;
+import com.Jessy1237.DwarfCraft.DwarfPlayer;
 import com.Jessy1237.DwarfCraft.DwarfTrainer;
-import com.Jessy1237.DwarfCraft.Skill;
 
 public class DwarfCraftDepositEvent extends Event implements Cancellable
 {
 
     private static final HandlerList handlers = new HandlerList();
     private boolean cancelled;
-    private DCPlayer player;
+    private DwarfPlayer player;
     private DwarfTrainer trainer;
-    private Skill skill;
+    private DwarfSkill skill;
 
     @Override
     public HandlerList getHandlers()
@@ -39,7 +39,7 @@ public class DwarfCraftDepositEvent extends Event implements Cancellable
     }
 
     /**
-     * The event for when a DCPlayer deposits into their skill. This event is fired
+     * The event for when a DwarfPlayer deposits into their skill. This event is fired
      * after the skill is levelled but before the data is saved.
      * 
      * @param player
@@ -49,7 +49,7 @@ public class DwarfCraftDepositEvent extends Event implements Cancellable
      * @param skill
      *            the skill that was levelled up
      */
-    public DwarfCraftDepositEvent( DCPlayer player, DwarfTrainer trainer, Skill skill )
+    public DwarfCraftDepositEvent( DwarfPlayer player, DwarfTrainer trainer, DwarfSkill skill )
     {
         this.player = player;
         this.trainer = trainer;
@@ -57,11 +57,11 @@ public class DwarfCraftDepositEvent extends Event implements Cancellable
     }
 
     /**
-     * Gets the DCPlayer that levelled up a skill.
+     * Gets the DwarfPlayer that levelled up a skill.
      * 
-     * @return DCPlayer
+     * @return DwarfPlayer
      */
-    public DCPlayer getDCPlayer()
+    public DwarfPlayer getDCPlayer()
     {
         return player;
     }
@@ -79,9 +79,9 @@ public class DwarfCraftDepositEvent extends Event implements Cancellable
     /**
      * Gets the skill that was deposited into.
      * 
-     * @return Skill
+     * @return DwarfSkill
      */
-    public Skill getSkill()
+    public DwarfSkill getSkill()
     {
         return skill;
     }

--- a/src/com/Jessy1237/DwarfCraft/events/DwarfCraftEffectEvent.java
+++ b/src/com/Jessy1237/DwarfCraft/events/DwarfCraftEffectEvent.java
@@ -1,5 +1,6 @@
 package com.Jessy1237.DwarfCraft.events;
 
+import com.Jessy1237.DwarfCraft.DwarfPlayer;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Cancellable;
@@ -7,16 +8,15 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
 
-import com.Jessy1237.DwarfCraft.DCPlayer;
-import com.Jessy1237.DwarfCraft.Effect;
+import com.Jessy1237.DwarfCraft.DwarfEffect;
 
 public class DwarfCraftEffectEvent extends Event implements Cancellable
 {
 
     private static final HandlerList handlers = new HandlerList();
     private boolean cancelled;
-    private DCPlayer player;
-    private Effect effect;
+    private DwarfPlayer player;
+    private DwarfEffect effect;
     private ItemStack[] orig;
     private ItemStack[] altered;
     private Integer origHunger;
@@ -28,7 +28,7 @@ public class DwarfCraftEffectEvent extends Event implements Cancellable
     private ItemStack itemInHand;
 
     /**
-     * The event for when an Effect is fired. This event is fired after the
+     * The event for when an DwarfEffect is fired. This event is fired after the
      * effect is fired but before any of the stats are applied to the
      * player/game.
      * 
@@ -68,7 +68,7 @@ public class DwarfCraftEffectEvent extends Event implements Cancellable
      *            allowed the effect to fire. i.e. a sword when killing an
      *            entity.
      */
-    public DwarfCraftEffectEvent( DCPlayer player, Effect effect, ItemStack[] orig, final ItemStack[] altered, Integer origHunger, Integer newHunger, Double origDmg, Double newDmg, Entity entity, Block block, ItemStack itemInHand )
+    public DwarfCraftEffectEvent( DwarfPlayer player, DwarfEffect effect, ItemStack[] orig, final ItemStack[] altered, Integer origHunger, Integer newHunger, Double origDmg, Double newDmg, Entity entity, Block block, ItemStack itemInHand )
     {
         this.player = player;
         this.effect = effect;
@@ -105,21 +105,21 @@ public class DwarfCraftEffectEvent extends Event implements Cancellable
     }
 
     /**
-     * Gets the DCPlayer that leveled up a skill.
+     * Gets the DwarfPlayer that leveled up a skill.
      * 
-     * @return DCPlayer
+     * @return DwarfPlayer
      */
-    public DCPlayer getDCPlayer()
+    public DwarfPlayer getDCPlayer()
     {
         return player;
     }
 
     /**
-     * Gets the Effect that was fired.
+     * Gets the DwarfEffect that was fired.
      * 
-     * @return Effect
+     * @return DwarfEffect
      */
-    public Effect getEffect()
+    public DwarfEffect getEffect()
     {
         return effect;
     }

--- a/src/com/Jessy1237/DwarfCraft/events/DwarfCraftLevelUpEvent.java
+++ b/src/com/Jessy1237/DwarfCraft/events/DwarfCraftLevelUpEvent.java
@@ -1,21 +1,21 @@
 package com.Jessy1237.DwarfCraft.events;
 
+import com.Jessy1237.DwarfCraft.DwarfPlayer;
+import com.Jessy1237.DwarfCraft.DwarfSkill;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
-import com.Jessy1237.DwarfCraft.DCPlayer;
 import com.Jessy1237.DwarfCraft.DwarfTrainer;
-import com.Jessy1237.DwarfCraft.Skill;
 
 public class DwarfCraftLevelUpEvent extends Event implements Cancellable
 {
 
     private static final HandlerList handlers = new HandlerList();
     private boolean cancelled;
-    private DCPlayer player;
+    private DwarfPlayer player;
     private DwarfTrainer trainer;
-    private Skill skill;
+    private DwarfSkill skill;
 
     @Override
     public HandlerList getHandlers()
@@ -39,7 +39,7 @@ public class DwarfCraftLevelUpEvent extends Event implements Cancellable
     }
 
     /**
-     * The event for when a DCPlayer levels up their skill. This event is fired
+     * The event for when a DwarfPlayer levels up their skill. This event is fired
      * after the skill is levelled but before the data is saved.
      * 
      * @param player
@@ -49,7 +49,7 @@ public class DwarfCraftLevelUpEvent extends Event implements Cancellable
      * @param skill
      *            the skill that was levelled up
      */
-    public DwarfCraftLevelUpEvent( DCPlayer player, DwarfTrainer trainer, Skill skill )
+    public DwarfCraftLevelUpEvent( DwarfPlayer player, DwarfTrainer trainer, DwarfSkill skill )
     {
         this.player = player;
         this.trainer = trainer;
@@ -57,11 +57,11 @@ public class DwarfCraftLevelUpEvent extends Event implements Cancellable
     }
 
     /**
-     * Gets the DCPlayer that levelled up a skill.
+     * Gets the DwarfPlayer that levelled up a skill.
      * 
-     * @return DCPlayer
+     * @return DwarfPlayer
      */
-    public DCPlayer getDCPlayer()
+    public DwarfPlayer getDCPlayer()
     {
         return player;
     }
@@ -79,9 +79,9 @@ public class DwarfCraftLevelUpEvent extends Event implements Cancellable
     /**
      * Gets the skill that was levelled up.
      * 
-     * @return Skill
+     * @return DwarfSkill
      */
-    public Skill getSkill()
+    public DwarfSkill getSkill()
     {
         return skill;
     }

--- a/src/com/Jessy1237/DwarfCraft/events/DwarfCraftLoadRacesEvent.java
+++ b/src/com/Jessy1237/DwarfCraft/events/DwarfCraftLoadRacesEvent.java
@@ -2,15 +2,14 @@ package com.Jessy1237.DwarfCraft.events;
 
 import java.util.ArrayList;
 
+import com.Jessy1237.DwarfCraft.DwarfRace;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-
-import com.Jessy1237.DwarfCraft.Race;
 
 public class DwarfCraftLoadRacesEvent extends Event
 {
     private static final HandlerList handlers = new HandlerList();
-    private ArrayList<Race> races = new ArrayList<Race>();
+    private ArrayList<DwarfRace> races = new ArrayList<DwarfRace>();
 
     @Override
     public HandlerList getHandlers()
@@ -32,7 +31,7 @@ public class DwarfCraftLoadRacesEvent extends Event
      *            The races that are going to be loaded into the DwarfCraft
      *            memory
      */
-    public DwarfCraftLoadRacesEvent( ArrayList<Race> races )
+    public DwarfCraftLoadRacesEvent( ArrayList<DwarfRace> races )
     {
         this.races = races;
     }
@@ -40,12 +39,12 @@ public class DwarfCraftLoadRacesEvent extends Event
     /**
      * Gets the races ArrayList
      * 
-     * @return DCPlayer
+     * @return DwarfPlayer
      */
     @SuppressWarnings( "unchecked" )
-    public ArrayList<Race> getRaces()
+    public ArrayList<DwarfRace> getRaces()
     {
-        return ( ArrayList<Race> ) races.clone();
+        return ( ArrayList<DwarfRace> ) races.clone();
     }
 
     /**
@@ -55,7 +54,7 @@ public class DwarfCraftLoadRacesEvent extends Event
      *            The races ArrayList to be loaded into the DwarfCraft memory
      * 
      */
-    public void setRaces( ArrayList<Race> races )
+    public void setRaces( ArrayList<DwarfRace> races )
     {
         this.races = races;
     }
@@ -68,7 +67,7 @@ public class DwarfCraftLoadRacesEvent extends Event
      *            A race to be added to the races ArrayList
      * 
      */
-    public void addSkill( Race race )
+    public void addSkill( DwarfRace race )
     {
 
     }
@@ -81,7 +80,7 @@ public class DwarfCraftLoadRacesEvent extends Event
      *            A race to be removed from the races ArrayList
      * 
      */
-    public void removeSkill( Race race )
+    public void removeSkill( DwarfRace race )
     {
         races.remove( race );
     }

--- a/src/com/Jessy1237/DwarfCraft/events/DwarfCraftLoadSkillsEvent.java
+++ b/src/com/Jessy1237/DwarfCraft/events/DwarfCraftLoadSkillsEvent.java
@@ -2,15 +2,14 @@ package com.Jessy1237.DwarfCraft.events;
 
 import java.util.HashMap;
 
+import com.Jessy1237.DwarfCraft.DwarfSkill;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-
-import com.Jessy1237.DwarfCraft.Skill;
 
 public class DwarfCraftLoadSkillsEvent extends Event
 {
     private static final HandlerList handlers = new HandlerList();
-    private HashMap<Integer, Skill> skills = new HashMap<Integer, Skill>();
+    private HashMap<Integer, DwarfSkill> skills = new HashMap<Integer, DwarfSkill>();
 
     @Override
     public HandlerList getHandlers()
@@ -32,21 +31,21 @@ public class DwarfCraftLoadSkillsEvent extends Event
      *            the skills that were loaded by DwarfCraft from the csv file.
      *            The key is the skill ID, the value is the skill.
      */
-    public DwarfCraftLoadSkillsEvent( HashMap<Integer, Skill> skills )
+    public DwarfCraftLoadSkillsEvent( HashMap<Integer, DwarfSkill> skills )
     {
         this.skills = skills;
     }
 
     /**
      * Gets the skills HashMap, the key is the skillID and the value is the
-     * Skill
+     * DwarfSkill
      * 
-     * @return DCPlayer
+     * @return DwarfPlayer
      */
     @SuppressWarnings( "unchecked" )
-    public HashMap<Integer, Skill> getSkills()
+    public HashMap<Integer, DwarfSkill> getSkills()
     {
-        return ( HashMap<Integer, Skill> ) skills.clone();
+        return ( HashMap<Integer, DwarfSkill> ) skills.clone();
     }
 
     /**
@@ -54,29 +53,29 @@ public class DwarfCraftLoadSkillsEvent extends Event
      * 
      * @param skills
      *            The skills HashMap, The key is the skillID, the value is the
-     *            Skill.
+     *            DwarfSkill.
      * 
      */
-    public void setSkills( HashMap<Integer, Skill> skills )
+    public void setSkills( HashMap<Integer, DwarfSkill> skills )
     {
         this.skills = skills;
     }
 
     /**
-     * Adds a skill to the Skill HashMap that is stored in the DwarfCraft
+     * Adds a skill to the DwarfSkill HashMap that is stored in the DwarfCraft
      * memory.
      * 
      * @param skill
      *            A skill to be added to the skills HashMap
      * 
      */
-    public void addSkill( Skill skill )
+    public void addSkill( DwarfSkill skill )
     {
         skills.put( skill.getId(), skill );
     }
 
     /**
-     * Removes a skill from the Skill HashMap that is stored in the DwarfCraft
+     * Removes a skill from the DwarfSkill HashMap that is stored in the DwarfCraft
      * memory.
      * 
      * @param skill
@@ -84,7 +83,7 @@ public class DwarfCraftLoadSkillsEvent extends Event
      * 
      */
     @SuppressWarnings( "unlikely-arg-type" )
-    public void removeSkill( Skill skill )
+    public void removeSkill( DwarfSkill skill )
     {
         skills.remove( skill );
     }

--- a/src/com/Jessy1237/DwarfCraft/events/DwarfCraftRaceChangeEvent.java
+++ b/src/com/Jessy1237/DwarfCraft/events/DwarfCraftRaceChangeEvent.java
@@ -1,18 +1,17 @@
 package com.Jessy1237.DwarfCraft.events;
 
+import com.Jessy1237.DwarfCraft.DwarfPlayer;
+import com.Jessy1237.DwarfCraft.DwarfRace;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-
-import com.Jessy1237.DwarfCraft.DCPlayer;
-import com.Jessy1237.DwarfCraft.Race;
 
 public class DwarfCraftRaceChangeEvent extends Event implements Cancellable
 {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancelled;
-    private DCPlayer player;
-    private Race race;
+    private DwarfPlayer player;
+    private DwarfRace race;
 
     @Override
     public HandlerList getHandlers()
@@ -35,18 +34,18 @@ public class DwarfCraftRaceChangeEvent extends Event implements Cancellable
         cancelled = cancel;
     }
 
-    public DwarfCraftRaceChangeEvent( DCPlayer player, Race race )
+    public DwarfCraftRaceChangeEvent( DwarfPlayer player, DwarfRace race )
     {
         this.player = player;
         this.race = race;
     }
 
     /**
-     * Gets the DCPlayer that levelled up a skill.
+     * Gets the DwarfPlayer that levelled up a skill.
      * 
-     * @return DCPlayer
+     * @return DwarfPlayer
      */
-    public DCPlayer getDCPlayer()
+    public DwarfPlayer getDwarfPlayer()
     {
         return player;
     }
@@ -54,9 +53,9 @@ public class DwarfCraftRaceChangeEvent extends Event implements Cancellable
     /**
      * Gets the race that the player is changing to.
      * 
-     * @return Race
+     * @return DwarfRace
      */
-    public Race getRace()
+    public DwarfRace getRace()
     {
         return race;
     }
@@ -68,7 +67,7 @@ public class DwarfCraftRaceChangeEvent extends Event implements Cancellable
      *            A dwarfcraft race that the player will change to.
      * 
      */
-    public void setRace( Race race )
+    public void setRace( DwarfRace race )
     {
         this.race = race;
     }

--- a/src/com/Jessy1237/DwarfCraft/guis/DwarfGUI.java
+++ b/src/com/Jessy1237/DwarfCraft/guis/DwarfGUI.java
@@ -1,0 +1,74 @@
+package com.Jessy1237.DwarfCraft.guis;
+
+import com.Jessy1237.DwarfCraft.DwarfPlayer;
+import com.Jessy1237.DwarfCraft.DwarfCraft;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+
+public abstract class DwarfGUI {
+
+    protected DwarfCraft plugin;
+    protected DwarfPlayer dwarfPlayer;
+    protected Inventory inventory;
+
+    public DwarfGUI(DwarfCraft plugin, DwarfPlayer player)
+    {
+        this.plugin = plugin;
+        this.dwarfPlayer = player;
+    }
+
+    public abstract void init();
+
+    public void openGUI()
+    {
+        if (dwarfPlayer != null && inventory != null)
+        {
+            dwarfPlayer.getPlayer().openInventory(inventory);
+        }
+    }
+
+    public DwarfPlayer getDwarfPlayer()
+    {
+        return dwarfPlayer;
+    }
+
+    public Inventory getInventory()
+    {
+        return inventory;
+    }
+
+    /**
+     * Adds an Item as a clickable option to the GUI
+     *
+     * @param name The display name of the item in the inventory
+     * @param lore The lore of the item in the inventory
+     * @param guiIndex This the index of the item slot
+     * @param item The item to be added as an option to the GUI
+     */
+    protected void addItem(String name, ArrayList<String> lore, int guiIndex, ItemStack item)
+    {
+        if (inventory == null)
+            return;
+
+        ItemMeta meta = item.getItemMeta();
+        if ( lore != null )
+            meta.setLore( lore );
+        if ( name != null )
+            meta.setDisplayName( name );
+        meta.addItemFlags( ItemFlag.HIDE_ATTRIBUTES );
+        meta.addItemFlags( ItemFlag.HIDE_ENCHANTS );
+        meta.addItemFlags( ItemFlag.HIDE_DESTROYS );
+        meta.addItemFlags( ItemFlag.HIDE_PLACED_ON );
+        meta.addItemFlags( ItemFlag.HIDE_POTION_EFFECTS );
+        meta.addItemFlags( ItemFlag.HIDE_UNBREAKABLE );
+
+        item.setItemMeta( meta );
+
+        inventory.setItem( guiIndex, item );
+    }
+}
+

--- a/src/com/Jessy1237/DwarfCraft/guis/InitTrainerGUISchedule.java
+++ b/src/com/Jessy1237/DwarfCraft/guis/InitTrainerGUISchedule.java
@@ -1,4 +1,4 @@
-package com.Jessy1237.DwarfCraft;
+package com.Jessy1237.DwarfCraft.guis;
 
 public class InitTrainerGUISchedule implements Runnable
 {
@@ -13,7 +13,7 @@ public class InitTrainerGUISchedule implements Runnable
     public void run()
     {
         trainerGUI.init();
-        trainerGUI.getDCPlayer().getPlayer().updateInventory();
+        trainerGUI.getDwarfPlayer().getPlayer().updateInventory();
         trainerGUI.openGUI();
     }
 }

--- a/src/com/Jessy1237/DwarfCraft/guis/ListTrainersGUI.java
+++ b/src/com/Jessy1237/DwarfCraft/guis/ListTrainersGUI.java
@@ -1,0 +1,62 @@
+package com.Jessy1237.DwarfCraft.guis;
+
+import com.Jessy1237.DwarfCraft.DwarfCraft;
+import com.Jessy1237.DwarfCraft.DwarfPlayer;
+import com.Jessy1237.DwarfCraft.DwarfSkill;
+import com.Jessy1237.DwarfCraft.DwarfTrainer;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class ListTrainersGUI extends DwarfGUI {
+
+    private DwarfTrainer[] trainers = null;
+    private int page = 1; //TODO Support multiple pages
+    private int inventorySize = 54;
+
+    public ListTrainersGUI(DwarfCraft plugin, DwarfPlayer dwarfPlayer)
+    {
+        super(plugin, dwarfPlayer);
+    }
+
+    @Override
+    public void init() {
+        Collection<DwarfTrainer> col = plugin.getDataManager().trainerList.values();
+        DwarfTrainer[] trainers = new DwarfTrainer[col.size()];
+        col.toArray(trainers);
+
+        this.trainers = trainers;
+        this.inventory = plugin.getServer().createInventory(dwarfPlayer.getPlayer(), inventorySize, "Trainers List");
+
+        System.out.println("Found " + trainers.length + " trainers to display");
+
+        //TODO: Better handle 0 trainers
+        int slot = 0;
+        for (int index = 0; index <= trainers.length - 1; index++) {
+            DwarfTrainer trainer = getTrainerAtSlot(index);
+            DwarfSkill skill = dwarfPlayer.getSkill(trainer.getSkillTrained());
+
+            ArrayList<String> lore = new ArrayList<>();
+            lore.add( ChatColor.GOLD + "Skill: " + ChatColor.RED + skill.getDisplayName());
+            lore.add( ChatColor.GOLD + "Min Level: " + ChatColor.WHITE + trainer.getMinSkill());
+            lore.add( ChatColor.GOLD + "Max Level: " + ChatColor.WHITE + trainer.getMaxSkill());
+            lore.add( ChatColor.GOLD + "Loc: " + ChatColor.WHITE + trainer.getLocation().getX() + ", " + trainer.getLocation().getY() + ", " + trainer.getLocation().getZ());
+            lore.add("");
+            lore.add( ChatColor.LIGHT_PURPLE + "Click to teleport to Trainer...");
+
+            addItem(trainer.getName(), lore, slot, new ItemStack(Material.SKULL_ITEM, 1, (short)3, (byte)3));
+            slot++;
+        }
+    }
+
+    public DwarfTrainer getTrainerAtSlot(int slot) {
+        if (trainers == null) return null;
+
+        int startTrainer = (page * inventorySize) - inventorySize;
+        return this.trainers[startTrainer + slot];
+    }
+
+}

--- a/src/com/Jessy1237/DwarfCraft/guis/TrainerGUI.java
+++ b/src/com/Jessy1237/DwarfCraft/guis/TrainerGUI.java
@@ -1,36 +1,34 @@
-package com.Jessy1237.DwarfCraft;
+package com.Jessy1237.DwarfCraft.guis;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import com.Jessy1237.DwarfCraft.*;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-public class TrainerGUI
+public class TrainerGUI extends DwarfGUI
 {
-    private DwarfCraft plugin;
     private DwarfTrainer trainer;
-    private DCPlayer player;
-    private Inventory inventory;
 
-    public TrainerGUI( DwarfCraft plugin, DwarfTrainer trainer, DCPlayer player, Inventory inventory )
+    public TrainerGUI(DwarfCraft plugin, DwarfTrainer trainer, DwarfPlayer dwarfPlayer)
     {
-        this.plugin = plugin;
+        super(plugin, dwarfPlayer);
+
         this.trainer = trainer;
-        this.player = player;
-        this.inventory = inventory;
     }
 
+    @Override
     public void init()
     {
+        DwarfSkill skill = dwarfPlayer.getSkill( trainer.getSkillTrained());
+        this.inventory = plugin.getServer().createInventory( dwarfPlayer.getPlayer(), 18, plugin.getOut().parseColors( Messages.trainerGUITitle.replaceAll( "%skillid%", "" + skill.getId() ).replaceAll( "%skillname%", "" + skill.getDisplayName() )
+                .replaceAll( "%skilllevel%", "" + skill.getLevel() ).replaceAll( "%maxskilllevel%", "" + plugin.getConfigManager().getMaxSkillLevel() ) ) );
         inventory.clear();
 
-        Skill skill = player.getSkill( trainer.getSkillTrained() );
-        List<List<ItemStack>> costs = player.calculateTrainingCost( skill );
+        List<List<ItemStack>> costs = dwarfPlayer.calculateTrainingCost( skill );
         List<ItemStack> trainingCostsToLevel = costs.get( 0 );
 
         int guiIndex = 0;
@@ -54,33 +52,15 @@ public class TrainerGUI
         addItem( "Deposit All", null, 12, guiItem );
 
         guiItem = new ItemStack( Material.INK_SACK, 1, ( short ) 10 );
-        addItem( "Train Skill", null, 13, guiItem );
+        addItem( "Train DwarfSkill", null, 13, guiItem );
 
         guiItem = new ItemStack( Material.INK_SACK, 1, ( short ) 2 );
-        addItem( "Train & Deposit Skill", null, 14, guiItem );
-    }
-
-    public void openGUI()
-    {
-        if ( player != null && inventory != null )
-        {
-            player.getPlayer().openInventory( inventory );
-        }
+        addItem( "Train & Deposit DwarfSkill", null, 14, guiItem );
     }
 
     public DwarfTrainer getTrainer()
     {
         return trainer;
-    }
-
-    public DCPlayer getDCPlayer()
-    {
-        return player;
-    }
-
-    public Inventory getInventory()
-    {
-        return inventory;
     }
 
     public void updateItem( ItemStack item, int amount )
@@ -97,7 +77,7 @@ public class TrainerGUI
                 ItemMeta meta = invStack.getItemMeta();
                 meta.setLore( lore );
                 invStack.setItemMeta( meta );
-                player.getPlayer().updateInventory();
+                dwarfPlayer.getPlayer().updateInventory();
                 return;
             }
         }
@@ -108,40 +88,13 @@ public class TrainerGUI
      */
     public void updateTitle()
     {
-        Skill skill = player.getSkill( trainer.getSkillTrained() );
-        player.getPlayer().closeInventory();
-        inventory = plugin.getServer().createInventory( player.getPlayer(), 18, plugin.getOut()
+        DwarfSkill skill = dwarfPlayer.getSkill( trainer.getSkillTrained() );
+        dwarfPlayer.getPlayer().closeInventory();
+        inventory = plugin.getServer().createInventory( dwarfPlayer.getPlayer(), 18, plugin.getOut()
                 .parseColors( Messages.trainerGUITitle.replaceAll( "%skillid%", "" + skill.getId() ).replaceAll( "%skillname%", "" + skill.getDisplayName() ).replaceAll( "%skilllevel%", "" + skill.getLevel() ).replaceAll( "%maxskilllevel%", "" + plugin.getConfigManager().getMaxSkillLevel() ) ) );
         init();
-        player.getPlayer().updateInventory();
+        dwarfPlayer.getPlayer().updateInventory();
         openGUI();
-        plugin.getDCInventoryListener().trainerGUIs.put( player.getPlayer(), this );
-    }
-
-    /**
-     * Adds an Item as a clickable option to the GUI
-     * 
-     * @param name The display name of the item in the inventory
-     * @param lore The lore of the item in the inventory
-     * @param guiIndex This the index of the item slot
-     * @param item The item to be added as an option to the GUI
-     */
-    private void addItem( String name, ArrayList<String> lore, int guiIndex, ItemStack item )
-    {
-        ItemMeta meta = item.getItemMeta();
-        if ( lore != null )
-            meta.setLore( lore );
-        if ( name != null )
-            meta.setDisplayName( name );
-        meta.addItemFlags( ItemFlag.HIDE_ATTRIBUTES );
-        meta.addItemFlags( ItemFlag.HIDE_ENCHANTS );
-        meta.addItemFlags( ItemFlag.HIDE_DESTROYS );
-        meta.addItemFlags( ItemFlag.HIDE_PLACED_ON );
-        meta.addItemFlags( ItemFlag.HIDE_POTION_EFFECTS );
-        meta.addItemFlags( ItemFlag.HIDE_UNBREAKABLE );
-
-        item.setItemMeta( meta );
-
-        inventory.setItem( guiIndex, item );
+        plugin.getDwarfInventoryListener().trainerGUIs.put( dwarfPlayer.getPlayer(), this );
     }
 }

--- a/src/com/Jessy1237/DwarfCraft/listeners/DwarfBlockListener.java
+++ b/src/com/Jessy1237/DwarfCraft/listeners/DwarfBlockListener.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 
+import com.Jessy1237.DwarfCraft.*;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -31,19 +32,15 @@ import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.MaterialData;
 
-import com.Jessy1237.DwarfCraft.DCPlayer;
-import com.Jessy1237.DwarfCraft.DwarfCraft;
-import com.Jessy1237.DwarfCraft.Effect;
-import com.Jessy1237.DwarfCraft.EffectType;
-import com.Jessy1237.DwarfCraft.Skill;
+import com.Jessy1237.DwarfCraft.DwarfPlayer;
 import com.Jessy1237.DwarfCraft.events.DwarfCraftEffectEvent;
 
-public class DCBlockListener implements Listener
+public class DwarfBlockListener implements Listener
 {
     private final DwarfCraft plugin;
     private HashMap<Block, Player> crops = new HashMap<Block, Player>();
 
-    public DCBlockListener( final DwarfCraft plugin )
+    public DwarfBlockListener( final DwarfCraft plugin )
     {
         this.plugin = plugin;
     }
@@ -120,8 +117,8 @@ public class DCBlockListener implements Listener
         if ( event.getPlayer().getGameMode() == GameMode.CREATIVE )
             return;
 
-        DCPlayer player = plugin.getDataManager().find( event.getPlayer() );
-        HashMap<Integer, Skill> skills = player.getSkills();
+        DwarfPlayer player = plugin.getDataManager().find( event.getPlayer() );
+        HashMap<Integer, DwarfSkill> skills = player.getSkills();
 
         ItemStack tool = player.getPlayer().getInventory().getItemInMainHand();
         Block block = event.getBlock();
@@ -138,9 +135,9 @@ public class DCBlockListener implements Listener
         }
 
         boolean blockDropChange = false;
-        for ( Skill s : skills.values() )
+        for ( DwarfSkill s : skills.values() )
         {
-            for ( Effect effect : s.getEffects() )
+            for ( DwarfEffect effect : s.getEffects() )
             {
                 if ( effect.getEffectType() == EffectType.BLOCKDROP && effect.checkInitiator( blockID, meta ) )
                 {
@@ -435,9 +432,9 @@ public class DCBlockListener implements Listener
 
         if ( tool != null && tool.getType().getMaxDurability() > 0 )
         {
-            for ( Skill s : skills.values() )
+            for ( DwarfSkill s : skills.values() )
             {
-                for ( Effect e : s.getEffects() )
+                for ( DwarfEffect e : s.getEffects() )
                 {
                     if ( e.getEffectType() == EffectType.SWORDDURABILITY && e.checkTool( tool ) )
                         e.damageTool( player, 2, tool, !blockDropChange );
@@ -471,8 +468,8 @@ public class DCBlockListener implements Listener
             return;
 
         Player player = event.getPlayer();
-        DCPlayer dCPlayer = plugin.getDataManager().find( player );
-        HashMap<Integer, Skill> skills = dCPlayer.getSkills();
+        DwarfPlayer dCPlayer = plugin.getDataManager().find( player );
+        HashMap<Integer, DwarfSkill> skills = dCPlayer.getSkills();
 
         // Effect Specific information
         ItemStack tool = player.getInventory().getItemInMainHand();
@@ -482,9 +479,9 @@ public class DCBlockListener implements Listener
         // if (event.getDamageLevel() != BlockDamageLevel.STARTED)
         // return;
 
-        for ( Skill s : skills.values() )
+        for ( DwarfSkill s : skills.values() )
         {
-            for ( Effect e : s.getEffects() )
+            for ( DwarfEffect e : s.getEffects() )
             {
                 if ( e.getEffectType() == EffectType.DIGTIME && e.checkInitiator( materialId, data ) && e.checkTool( tool ) )
                 {
@@ -551,10 +548,10 @@ public class DCBlockListener implements Listener
                         {
                             if ( b.getX() == x && b.getY() == y && b.getZ() == z )
                             {
-                                DCPlayer dCPlayer = plugin.getDataManager().find( crops.get( b ) );
-                                for ( Skill s : dCPlayer.getSkills().values() )
+                                DwarfPlayer dCPlayer = plugin.getDataManager().find( crops.get( b ) );
+                                for ( DwarfSkill s : dCPlayer.getSkills().values() )
                                 {
-                                    for ( Effect e : s.getEffects() )
+                                    for ( DwarfEffect e : s.getEffects() )
                                     {
                                         if ( e.getEffectType() == EffectType.BLOCKDROP && e.checkInitiator( new ItemStack( Material.CACTUS ) ) )
                                         {
@@ -631,10 +628,10 @@ public class DCBlockListener implements Listener
                     {
                         if ( b.getX() == x && b.getY() == y && b.getZ() == z )
                         {
-                            DCPlayer dCPlayer = plugin.getDataManager().find( crops.get( b ) );
-                            for ( Skill s : dCPlayer.getSkills().values() )
+                            DwarfPlayer dCPlayer = plugin.getDataManager().find( crops.get( b ) );
+                            for ( DwarfSkill s : dCPlayer.getSkills().values() )
                             {
-                                for ( Effect e : s.getEffects() )
+                                for ( DwarfEffect e : s.getEffects() )
                                 {
                                     if ( e.getEffectType() == EffectType.BLOCKDROP && e.checkInitiator( new ItemStack( Material.SUGAR_CANE_BLOCK ) ) )
                                     {

--- a/src/com/Jessy1237/DwarfCraft/listeners/DwarfListener.java
+++ b/src/com/Jessy1237/DwarfCraft/listeners/DwarfListener.java
@@ -1,20 +1,20 @@
 package com.Jessy1237.DwarfCraft.listeners;
 
+import com.Jessy1237.DwarfCraft.DwarfSkill;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
-import com.Jessy1237.DwarfCraft.DCPlayer;
+import com.Jessy1237.DwarfCraft.DwarfPlayer;
 import com.Jessy1237.DwarfCraft.DwarfCraft;
-import com.Jessy1237.DwarfCraft.Skill;
 import com.Jessy1237.DwarfCraft.events.DwarfCraftLevelUpEvent;
 
-public class DCListener implements Listener
+public class DwarfListener implements Listener
 {
 
     private final DwarfCraft plugin;
 
-    public DCListener( final DwarfCraft plugin )
+    public DwarfListener( final DwarfCraft plugin )
     {
         this.plugin = plugin;
     }
@@ -22,8 +22,8 @@ public class DCListener implements Listener
     @EventHandler( priority = EventPriority.NORMAL, ignoreCancelled = true )
     public void onDwarfCraftLevelUp( DwarfCraftLevelUpEvent event )
     {
-        DCPlayer player = event.getDCPlayer();
-        Skill skill = event.getSkill();
+        DwarfPlayer player = event.getDCPlayer();
+        DwarfSkill skill = event.getSkill();
 
         if ( skill.getLevel() % plugin.getConfigManager().getAnnouncementInterval() == 0 && plugin.getConfigManager().announce )
         {

--- a/src/com/Jessy1237/DwarfCraft/listeners/DwarfPlayerListener.java
+++ b/src/com/Jessy1237/DwarfCraft/listeners/DwarfPlayerListener.java
@@ -6,6 +6,7 @@ package com.Jessy1237.DwarfCraft.listeners;
 
 import java.util.HashMap;
 
+import com.Jessy1237.DwarfCraft.*;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -28,19 +29,14 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerShearEntityEvent;
 import org.bukkit.inventory.ItemStack;
 
-import com.Jessy1237.DwarfCraft.DCPlayer;
-import com.Jessy1237.DwarfCraft.DwarfCraft;
-import com.Jessy1237.DwarfCraft.Effect;
-import com.Jessy1237.DwarfCraft.EffectType;
-import com.Jessy1237.DwarfCraft.Skill;
-import com.Jessy1237.DwarfCraft.Util;
+import com.Jessy1237.DwarfCraft.DwarfPlayer;
 import com.Jessy1237.DwarfCraft.events.DwarfCraftEffectEvent;
 
-public class DCPlayerListener implements Listener
+public class DwarfPlayerListener implements Listener
 {
     private final DwarfCraft plugin;
 
-    public DCPlayerListener( final DwarfCraft plugin )
+    public DwarfPlayerListener( final DwarfCraft plugin )
     {
         this.plugin = plugin;
     }
@@ -76,8 +72,8 @@ public class DCPlayerListener implements Listener
             return;
 
         Player player = event.getPlayer();
-        DCPlayer dcPlayer = plugin.getDataManager().find( player );
-        HashMap<Integer, Skill> skills = dcPlayer.getSkills();
+        DwarfPlayer dwarfPlayer = plugin.getDataManager().find( player );
+        HashMap<Integer, DwarfSkill> skills = dwarfPlayer.getSkills();
 
         // ItemStack item = player.getItemInHand(); Does this work the same as
         // below?
@@ -91,13 +87,13 @@ public class DCPlayerListener implements Listener
 
             if ( material == Material.DIRT || material == Material.GRASS )
             {
-                for ( Skill s : skills.values() )
+                for ( DwarfSkill s : skills.values() )
                 {
-                    for ( Effect effect : s.getEffects() )
+                    for ( DwarfEffect effect : s.getEffects() )
                     {
                         if ( effect.getEffectType() == EffectType.PLOWDURABILITY && effect.checkTool( item ) )
                         {
-                            effect.damageTool( dcPlayer, 1, item );
+                            effect.damageTool(dwarfPlayer, 1, item );
                             // block.setTypeId(60);
                         }
                     }
@@ -111,18 +107,18 @@ public class DCPlayerListener implements Listener
         // EffectType.EAT
         if ( event.getAction() == Action.RIGHT_CLICK_BLOCK )
         {
-            for ( Skill s : skills.values() )
+            for ( DwarfSkill s : skills.values() )
             {
-                for ( Effect e : s.getEffects() )
+                for ( DwarfEffect e : s.getEffects() )
                 {
                     if ( e.getEffectType() == EffectType.EAT && e.checkInitiator( block.getTypeId(), block.getData() ) )
                     {
 
-                        int foodLevel = plugin.getUtil().randomAmount( ( e.getEffectAmount( dcPlayer ) ) );
+                        int foodLevel = plugin.getUtil().randomAmount( ( e.getEffectAmount(dwarfPlayer) ) );
 
                         if ( block.getType() == Material.CAKE_BLOCK )
                         {
-                            DwarfCraftEffectEvent ev = new DwarfCraftEffectEvent( dcPlayer, e, null, null, 2, foodLevel, null, null, null, block, null );
+                            DwarfCraftEffectEvent ev = new DwarfCraftEffectEvent(dwarfPlayer, e, null, null, 2, foodLevel, null, null, null, block, null );
                             plugin.getServer().getPluginManager().callEvent( ev );
 
                             if ( ev.isCancelled() )
@@ -155,8 +151,8 @@ public class DCPlayerListener implements Listener
         Player player = event.getPlayer();
         ItemStack item = event.getItem();
         int id = item.getTypeId();
-        DCPlayer dcPlayer = plugin.getDataManager().find( player );
-        HashMap<Integer, Skill> skills = dcPlayer.getSkills();
+        DwarfPlayer dwarfPlayer = plugin.getDataManager().find( player );
+        HashMap<Integer, DwarfSkill> skills = dwarfPlayer.getSkills();
         int lvl = Util.FoodLevel.getLvl( id );
 
         if ( lvl == 0 )
@@ -164,15 +160,15 @@ public class DCPlayerListener implements Listener
             return;
         }
 
-        for ( Skill s : skills.values() )
+        for ( DwarfSkill s : skills.values() )
         {
-            for ( Effect e : s.getEffects() )
+            for ( DwarfEffect e : s.getEffects() )
             {
                 if ( e.getEffectType() == EffectType.EAT && e.checkInitiator( item ) )
                 {
-                    int foodLevel = plugin.getUtil().randomAmount( ( e.getEffectAmount( dcPlayer ) ) );
+                    int foodLevel = plugin.getUtil().randomAmount( ( e.getEffectAmount(dwarfPlayer) ) );
 
-                    DwarfCraftEffectEvent ev = new DwarfCraftEffectEvent( dcPlayer, e, null, null, lvl, foodLevel, null, null, null, null, item );
+                    DwarfCraftEffectEvent ev = new DwarfCraftEffectEvent(dwarfPlayer, e, null, null, lvl, foodLevel, null, null, null, null, item );
                     plugin.getServer().getPluginManager().callEvent( ev );
 
                     if ( ev.isCancelled() )
@@ -193,13 +189,13 @@ public class DCPlayerListener implements Listener
 
         Player player = event.getPlayer();
         Entity entity = event.getEntity();
-        DCPlayer dcPlayer = plugin.getDataManager().find( player );
-        HashMap<Integer, Skill> skills = dcPlayer.getSkills();
+        DwarfPlayer dwarfPlayer = plugin.getDataManager().find( player );
+        HashMap<Integer, DwarfSkill> skills = dwarfPlayer.getSkills();
         boolean changed = false;
 
-        for ( Skill s : skills.values() )
+        for ( DwarfSkill s : skills.values() )
         {
-            for ( Effect e : s.getEffects() )
+            for ( DwarfEffect e : s.getEffects() )
             {
                 if ( e.getEffectType() == EffectType.SHEAR )
                 {
@@ -211,9 +207,9 @@ public class DCPlayerListener implements Listener
                             if ( sheep.isAdult() )
                             {
 
-                                ItemStack item = e.getOutput( dcPlayer, sheep.getColor().getWoolData(), -1 );
+                                ItemStack item = e.getOutput(dwarfPlayer, sheep.getColor().getWoolData(), -1 );
 
-                                DwarfCraftEffectEvent ev = new DwarfCraftEffectEvent( dcPlayer, e, new ItemStack[] { new ItemStack( item.getTypeId(), 2, sheep.getColor().getWoolData() ) }, new ItemStack[] { item }, null, null, null, null, entity, null, player.getItemInHand() );
+                                DwarfCraftEffectEvent ev = new DwarfCraftEffectEvent(dwarfPlayer, e, new ItemStack[] { new ItemStack( item.getTypeId(), 2, sheep.getColor().getWoolData() ) }, new ItemStack[] { item }, null, null, null, null, entity, null, player.getItemInHand() );
                                 plugin.getServer().getPluginManager().callEvent( ev );
 
                                 if ( ev.isCancelled() )
@@ -240,9 +236,9 @@ public class DCPlayerListener implements Listener
                         MushroomCow mooshroom = ( MushroomCow ) entity;
                         if ( mooshroom.isAdult() )
                         {
-                            ItemStack item = e.getOutput( dcPlayer );
+                            ItemStack item = e.getOutput(dwarfPlayer);
 
-                            DwarfCraftEffectEvent ev = new DwarfCraftEffectEvent( dcPlayer, e, new ItemStack[] { new ItemStack( Material.RED_MUSHROOM, 5 ) }, new ItemStack[] { item }, null, null, null, null, entity, null, player.getItemInHand() );
+                            DwarfCraftEffectEvent ev = new DwarfCraftEffectEvent(dwarfPlayer, e, new ItemStack[] { new ItemStack( Material.RED_MUSHROOM, 5 ) }, new ItemStack[] { item }, null, null, null, null, entity, null, player.getItemInHand() );
                             plugin.getServer().getPluginManager().callEvent( ev );
 
                             if ( ev.isCancelled() )
@@ -302,7 +298,7 @@ public class DCPlayerListener implements Listener
 
         if ( event.getState() == State.CAUGHT_FISH )
         {
-            DCPlayer player = plugin.getDataManager().find( event.getPlayer() );
+            DwarfPlayer player = plugin.getDataManager().find( event.getPlayer() );
             ItemStack item = ( ( Item ) event.getCaught() ).getItemStack();
             byte meta = item.getData().getData();
             Location loc = player.getPlayer().getLocation();
@@ -315,9 +311,9 @@ public class DCPlayerListener implements Listener
 
             if ( item.getType() == Material.RAW_FISH )
             {
-                for ( Skill skill : player.getSkills().values() )
+                for ( DwarfSkill skill : player.getSkills().values() )
                 {
-                    for ( Effect effect : skill.getEffects() )
+                    for ( DwarfEffect effect : skill.getEffects() )
                     {
                         if ( effect.getEffectType() == EffectType.FISH )
                         {
@@ -346,9 +342,9 @@ public class DCPlayerListener implements Listener
 
                 if ( tool != null && tool.getType().getMaxDurability() > 0 )
                 {
-                    for ( Skill s : player.getSkills().values() )
+                    for ( DwarfSkill s : player.getSkills().values() )
                     {
-                        for ( Effect e : s.getEffects() )
+                        for ( DwarfEffect e : s.getEffects() )
                         {
                             if ( e.getEffectType() == EffectType.RODDURABILITY && e.checkTool( tool ) )
                                 e.damageTool( player, 1, tool );

--- a/src/com/Jessy1237/DwarfCraft/listeners/DwarfVehicleListener.java
+++ b/src/com/Jessy1237/DwarfCraft/listeners/DwarfVehicleListener.java
@@ -4,6 +4,7 @@ package com.Jessy1237.DwarfCraft.listeners;
  * Original Authors: smartaleq, LexManos and RCarretta
  */
 
+import com.Jessy1237.DwarfCraft.*;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Boat;
@@ -17,19 +18,14 @@ import org.bukkit.event.vehicle.VehicleExitEvent;
 import org.bukkit.event.vehicle.VehicleMoveEvent;
 import org.bukkit.inventory.ItemStack;
 
-import com.Jessy1237.DwarfCraft.DCPlayer;
-import com.Jessy1237.DwarfCraft.DwarfCraft;
-import com.Jessy1237.DwarfCraft.DwarfVehicle;
-import com.Jessy1237.DwarfCraft.Effect;
-import com.Jessy1237.DwarfCraft.EffectType;
-import com.Jessy1237.DwarfCraft.Skill;
+import com.Jessy1237.DwarfCraft.DwarfSkill;
 import com.Jessy1237.DwarfCraft.events.DwarfCraftEffectEvent;
 
-public class DCVehicleListener implements Listener
+public class DwarfVehicleListener implements Listener
 {
     private final DwarfCraft plugin;
 
-    public DCVehicleListener( final DwarfCraft plugin )
+    public DwarfVehicleListener( final DwarfCraft plugin )
     {
         this.plugin = plugin;
     }
@@ -54,18 +50,18 @@ public class DCVehicleListener implements Listener
             {
 
                 Player player = ( Player ) event.getAttacker();
-                DCPlayer dcPlayer = plugin.getDataManager().find( player );
+                DwarfPlayer dwarfPlayer = plugin.getDataManager().find( player );
                 Location loc = event.getVehicle().getLocation();
 
-                for ( Skill skill : dcPlayer.getSkills().values() )
+                for ( DwarfSkill skill : dwarfPlayer.getSkills().values() )
                 {
-                    for ( Effect effect : skill.getEffects() )
+                    for ( DwarfEffect effect : skill.getEffects() )
                     {
                         if ( effect.getEffectType() == EffectType.VEHICLEDROP )
                         {
-                            ItemStack drop = effect.getOutput( dcPlayer );
+                            ItemStack drop = effect.getOutput(dwarfPlayer);
 
-                            DwarfCraftEffectEvent ev = new DwarfCraftEffectEvent( dcPlayer, effect, new ItemStack[] { new ItemStack( Material.BOAT, 1 ) }, new ItemStack[] { drop }, null, null, null, null, event.getVehicle().getVehicle(), null, null );
+                            DwarfCraftEffectEvent ev = new DwarfCraftEffectEvent(dwarfPlayer, effect, new ItemStack[] { new ItemStack( Material.BOAT, 1 ) }, new ItemStack[] { drop }, null, null, null, null, event.getVehicle().getVehicle(), null, null );
                             plugin.getServer().getPluginManager().callEvent( ev );
 
                             if ( ev.isCancelled() )
@@ -137,12 +133,12 @@ public class DCVehicleListener implements Listener
         if ( !( event.getVehicle().getPassenger() instanceof Player ) )
             return;
 
-        DCPlayer dCPlayer = plugin.getDataManager().find( ( Player ) event.getVehicle().getPassenger() );
+        DwarfPlayer dCPlayer = plugin.getDataManager().find( ( Player ) event.getVehicle().getPassenger() );
         double effectAmount = 1.0;
-        Effect effect = null;
-        for ( Skill s : dCPlayer.getSkills().values() )
+        DwarfEffect effect = null;
+        for ( DwarfSkill s : dCPlayer.getSkills().values() )
         {
-            for ( Effect e : s.getEffects() )
+            for ( DwarfEffect e : s.getEffects() )
             {
                 if ( e.getEffectType() == EffectType.VEHICLEMOVE )
                 {


### PR DESCRIPTION
This commit refactors many parts of the DwarfCraft codebase. This aims to bring a more consistent naming convention to classes. It also moves all GUI code to a new GUI package and implements an abstract DwarfGUI base class.

Finally it comes with a new feature which is the List Trainers GUI. Previously the /listtrainers command listed all the trainers in the game chat. This was hard to read and hardly used because of this. I have started adding the trainers list into a GUI where you can see the trained skill of the trainer, the min level, max level, and their current world coords. Left clicking the trainer will teleport you one block away from them. This is meant to be an admin command but you could give players access to it through permissions if you really wanted to.

Please keep in mind that this is very WIP (Work in Progress) and will be buggy. Not everything is implemented yet. This is a developer release, it is not recommended you put this on your server.

Known Bugs:
- Shift-Clicking items in TrainerList GUI allows you to take the items



Trainers List GUI:

<img width="546" alt="screen shot 2018-01-31 at 2 56 48 pm" src="https://user-images.githubusercontent.com/1168966/35644464-0183fa26-0697-11e8-9280-f5100d5dfee1.png">

Trainer GUI (previously implemented in the last couple commits):
<img width="417" alt="screen shot 2018-01-31 at 4 03 10 pm" src="https://user-images.githubusercontent.com/1168966/35647364-4b6b8182-06a0-11e8-8fa3-1bebb6dc6f54.png">
