### PR TITLE
Add support for deploying to GitHub Packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.Jessy1237</groupId>
-    <artifactId>DwarfCraft</artifactId>
+    <groupId>com.jessy1237</groupId>
+    <artifactId>dwarfcraft</artifactId>
     <name>DwarfCraft</name>
     <packaging>jar</packaging>
     <version>4.3.0-SNAPSHOT</version>
@@ -70,6 +70,14 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Jessy1237 Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/jessy1237/dwarfcraft</url>
+        </repository>
+    </distributionManagement>
 
     <build>
         <defaultGoal>package</defaultGoal>


### PR DESCRIPTION
`mvn deploy` will now publish the package to GitHub Packages with an authenticated server in your `~/.m2/settings.xml` file.

A personal access token with write packages permissions to the repo can create deployments.
See the link below for an example `~/.m2/settings.xml` file

- GitHub Settings > Developer Settings > Personal Access Tokens
- Create a new token with `package write` permissions
- Use the generated token as the password for the server in your `~/.m2/settings.xml`
- `USERNAME` should be replaced with your own username
- `OWNER` must be replaced with repository owner ( must be lowercase )
- All artifact ids are case sensitive and must be lowercase

See https://docs.github.com/en/packages/guides/configuring-apache-maven-for-use-with-github-packages#authenticating-to-github-packages